### PR TITLE
Improve CarritoItems GUI with auto-fill combos

### DIFF
--- a/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_Gui.fxml
+++ b/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_Gui.fxml
@@ -19,10 +19,10 @@
                     <children>
                         <Label layoutX="96.0" layoutY="36.0" text="ID:" />
                         <TextField fx:id="txt_id" layoutX="160.0" layoutY="32.0" prefWidth="400.0" />
-                        <Label layoutX="56.0" layoutY="72.0" text="Carrito ID:" />
-                        <TextField fx:id="txt_carrito" layoutX="160.0" layoutY="68.0" prefWidth="400.0" />
-                        <Label layoutX="48.0" layoutY="108.0" text="Variante ID:" />
-                        <TextField fx:id="txt_variante" layoutX="160.0" layoutY="104.0" prefWidth="400.0" />
+                        <Label layoutX="56.0" layoutY="72.0" text="Carrito:" />
+                        <ComboBox fx:id="cmb_carrito" layoutX="160.0" layoutY="68.0" prefWidth="400.0" />
+                        <Label layoutX="48.0" layoutY="108.0" text="Variante:" />
+                        <ComboBox fx:id="cmb_variante" layoutX="160.0" layoutY="104.0" prefWidth="400.0" />
                         <Label layoutX="92.0" layoutY="144.0" text="Cantidad:" />
                         <TextField fx:id="txt_cantidad" layoutX="160.0" layoutY="140.0" prefWidth="400.0" />
                     </children>

--- a/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_GuiController.java
+++ b/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_GuiController.java
@@ -1,7 +1,11 @@
 package proyectobd.CarritoItemsGui;
 
 import dao.CarritoItemDAO;
+import dao.CarritoDAO;
+import dao.VarianteProductoDAO;
 import dto.CarritoItemDTO;
+import dto.CarritoDTO;
+import dto.VarianteProductoDTO;
 import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.application.Platform;
@@ -9,6 +13,9 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ComboBox;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackCarritoItem;
@@ -22,13 +29,16 @@ public class Mnt_CarritoItems_GuiController implements Initializable {
     @FXML private Button btn_Grabar;
     @FXML private Button btn_Cerrar;
     @FXML private TextField txt_id;
-    @FXML private TextField txt_carrito;
-    @FXML private TextField txt_variante;
+    @FXML private ComboBox<Integer> cmb_carrito;
+    @FXML private ComboBox<Integer> cmb_variante;
     @FXML private TextField txt_cantidad;
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
-        Platform.runLater(() -> { cargarDatos(); });
+        Platform.runLater(() -> {
+            cargarCombos();
+            cargarDatos();
+        });
     }
 
     public void call_Grabar(){
@@ -36,8 +46,8 @@ public class Mnt_CarritoItems_GuiController implements Initializable {
         if(!actualizar){
             try{
                 CarritoItemDTO dto = new CarritoItemDTO();
-                dto.setCarritoId(Integer.parseInt(txt_carrito.getText()));
-                dto.setVarianteId(Integer.parseInt(txt_variante.getText()));
+                dto.setCarritoId(cmb_carrito.getValue());
+                dto.setVarianteId(cmb_variante.getValue());
                 dto.setCantidad(Integer.parseInt(txt_cantidad.getText()));
                 int id = dao.InsertarItem(dto);
                 if(id>0){
@@ -50,8 +60,8 @@ public class Mnt_CarritoItems_GuiController implements Initializable {
         }else{
             Stage stage = (Stage) Ap_Main.getScene().getWindow();
             CarritoItemDTO dto = (CarritoItemDTO) stage.getUserData();
-            dto.setCarritoId(Integer.parseInt(txt_carrito.getText()));
-            dto.setVarianteId(Integer.parseInt(txt_variante.getText()));
+            dto.setCarritoId(cmb_carrito.getValue());
+            dto.setVarianteId(cmb_variante.getValue());
             dto.setCantidad(Integer.parseInt(txt_cantidad.getText()));
             try{
                 dao.ActualizarItem(dto);
@@ -67,14 +77,34 @@ public class Mnt_CarritoItems_GuiController implements Initializable {
         stage.close();
     }
 
+    private void cargarCombos(){
+        try {
+            ObservableList<Integer> carritos = FXCollections.observableArrayList();
+            CarritoDAO cdao = new CarritoDAO();
+            for (CarritoDTO c : cdao.ListarCarritos()) {
+                carritos.add(c.getId());
+            }
+            cmb_carrito.setItems(carritos);
+
+            ObservableList<Integer> variantes = FXCollections.observableArrayList();
+            VarianteProductoDAO vdao = new VarianteProductoDAO();
+            for (VarianteProductoDTO v : vdao.ListarVariantes()) {
+                variantes.add(v.getId());
+            }
+            cmb_variante.setItems(variantes);
+        } catch (Exception ex) {
+            fu.MostrarAlertas("Error", ex.toString());
+        }
+    }
+
     private void cargarDatos(){
         Stage stage = (Stage) Ap_Main.getScene().getWindow();
         CarritoItemDTO dto = (CarritoItemDTO) stage.getUserData();
         if(dto != null){
             actualizar = true;
             txt_id.setText(Integer.toString(dto.getId()));
-            txt_carrito.setText(Integer.toString(dto.getCarritoId()));
-            txt_variante.setText(Integer.toString(dto.getVarianteId()));
+            cmb_carrito.setValue(dto.getCarritoId());
+            cmb_variante.setValue(dto.getVarianteId());
             txt_cantidad.setText(Integer.toString(dto.getCantidad()));
         }
     }


### PR DESCRIPTION
## Summary
- add combo boxes for carrito and variante selection
- populate combo boxes from database

## Testing
- `ant -version` *(fails: command not found)*
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7e61f1348332b9d20d7710219dbe