### PR TITLE
Simplify UI styles for multiple modules

### DIFF
--- a/src/proyectobd/CarritosGui/Mnt_Carritos_Gui.fxml
+++ b/src/proyectobd/CarritosGui/Mnt_Carritos_Gui.fxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.*?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 

--- a/src/proyectobd/CuponesGui/Lst_Cupones_Gui.fxml
+++ b/src/proyectobd/CuponesGui/Lst_Cupones_Gui.fxml
@@ -4,12 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane prefHeight="700.0" prefWidth="1000.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CuponesGui.Lst_Cupones_GuiController">
+<BorderPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CuponesGui.Lst_Cupones_GuiController">
    <top>
-      <VBox styleClass="header-section">
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-pane">
-            <Label text="🎟️ Gestión de Cupones" styleClass="header-title">
-               <font><Font name="System Bold" size="24.0"/></font>
+      <VBox>
+         <HBox alignment="CENTER" prefHeight="60.0">
+            <Label text="Panel de Gestión de Cupones">
             </Label>
          </HBox>
          <Separator/>
@@ -17,39 +16,36 @@
    </top>
 
    <center>
-      <VBox spacing="10.0" styleClass="content-area">
+      <VBox spacing="10.0">
          <padding>
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox styleClass="filter-section">
-            <Label text="🔍 Filtros de Búsqueda" styleClass="section-title">
-               <font><Font name="System Bold" size="16.0"/></font>
+         <VBox>
+            <Label text="Filtros de Búsqueda">
             </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0" styleClass="filter-container">
+            <HBox alignment="CENTER_LEFT" spacing="15.0">
                <padding>
                   <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
                </padding>
-               <Label text="ID o Código:" styleClass="filter-label">
-                  <font><Font name="System Bold" size="12.0"/></font>
+               <Label text="ID o Código:">
                </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..." styleClass="search-field"/>
-               <Button text="🔍 Buscar" onAction="#call_Buscar" styleClass="search-button"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="🔄 Limpiar" styleClass="clear-button"/>
+               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
+               <Button text="Buscar" onAction="#call_Buscar"/>
+               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
             </HBox>
          </VBox>
 
-         <VBox VBox.vgrow="ALWAYS" styleClass="table-section">
+         <VBox VBox.vgrow="ALWAYS">
             <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="📋 Lista de Cupones" styleClass="section-title">
-                  <font><Font name="System Bold" size="16.0"/></font>
+               <Label text="Lista de Cupones">
                </Label>
             </HBox>
-            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS" styleClass="modern-table">
+            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
-                  <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
                   <TableColumn fx:id="col_codigo" prefWidth="150.0" text="Código"/>
-                  <TableColumn fx:id="col_descuento" prefWidth="100.0" text="Descuento" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_descuento" prefWidth="100.0" text="Descuento"/>
                   <TableColumn fx:id="col_expira" prefWidth="150.0" text="Expira"/>
                </columns>
                <columnResizePolicy>
@@ -61,25 +57,17 @@
    </center>
 
    <bottom>
-      <VBox styleClass="footer-section">
+      <VBox>
          <Separator/>
-         <HBox alignment="CENTER_RIGHT" spacing="10.0" styleClass="action-bar">
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
             <padding>
                <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
             </padding>
             <Region HBox.hgrow="ALWAYS"/>
-            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" styleClass="primary-button">
-               <graphic><Label text="➕ Nuevo"/></graphic>
-            </Button>
-            <Button fx:id="btn_Editar" onAction="#call_Editar" styleClass="secondary-button">
-               <graphic><Label text="✏️ Editar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Borrar" onAction="#call_Borrar" styleClass="danger-button">
-               <graphic><Label text="🗑️ Borrar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" styleClass="default-button">
-               <graphic><Label text="❌ Cerrar"/></graphic>
-            </Button>
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
          </HBox>
       </VBox>
    </bottom>

--- a/src/proyectobd/CuponesGui/Lst_Cupones_GuiController.java
+++ b/src/proyectobd/CuponesGui/Lst_Cupones_GuiController.java
@@ -76,7 +76,7 @@ public class Lst_Cupones_GuiController implements Initializable {
         try{
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/CuponesGui/Mnt_Cupones_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Cupones");
+            stage.setTitle("Formulario de Mantenimiento de Cupones");
             stage.setScene(new Scene(root));
             stage.showAndWait();
             call_CargarDatos();
@@ -94,7 +94,7 @@ public class Lst_Cupones_GuiController implements Initializable {
             }
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/CuponesGui/Mnt_Cupones_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Cupones");
+            stage.setTitle("Formulario de Mantenimiento de Cupones");
             stage.setScene(new Scene(root));
             stage.setUserData(dto);
             stage.showAndWait();

--- a/src/proyectobd/CuponesGui/Mnt_Cupones_Gui.fxml
+++ b/src/proyectobd/CuponesGui/Mnt_Cupones_Gui.fxml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.*?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CuponesGui.Mnt_Cupones_GuiController">
+<AnchorPane fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CuponesGui.Mnt_Cupones_GuiController">
     <children>
-        <Pane prefHeight="50.0" prefWidth="800.0" styleClass="header-pane">
+        <Pane prefHeight="50.0" prefWidth="800.0">
             <children>
-                <Label layoutX="232.0" layoutY="12.0" text="Mantenimiento de Cupones" styleClass="header-label" />
+                <Label layoutX="232.0" layoutY="12.0" text="Formulario de Mantenimiento de Cupones" />
             </children>
         </Pane>
         <TitledPane layoutY="39.0" prefHeight="300.0" prefWidth="800.0" text="Detalles del Registro" animated="false">
@@ -33,8 +34,8 @@
             <content>
                 <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
                     <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" styleClass="action-button" />
-                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" styleClass="action-button" />
+                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
+                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
                     </children>
                 </AnchorPane>
             </content>

--- a/src/proyectobd/EnviosGui/Lst_Envios_Gui.fxml
+++ b/src/proyectobd/EnviosGui/Lst_Envios_Gui.fxml
@@ -4,12 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane prefHeight="700.0" prefWidth="1000.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.EnviosGui.Lst_Envios_GuiController">
+<BorderPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.EnviosGui.Lst_Envios_GuiController">
    <top>
-      <VBox styleClass="header-section">
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-pane">
-            <Label text="📦 Sistema de Gestión de Envíos" styleClass="header-title">
-               <font><Font name="System Bold" size="24.0"/></font>
+      <VBox>
+         <HBox alignment="CENTER" prefHeight="60.0">
+            <Label text="Panel de Gestión de Envíos">
             </Label>
          </HBox>
          <Separator/>
@@ -17,44 +16,41 @@
    </top>
 
    <center>
-      <VBox spacing="10.0" styleClass="content-area">
+      <VBox spacing="10.0">
          <padding>
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox styleClass="filter-section">
-            <Label text="🔍 Filtros de Búsqueda" styleClass="section-title">
-               <font><Font name="System Bold" size="16.0"/></font>
+         <VBox>
+            <Label text="Filtros de Búsqueda">
             </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0" styleClass="filter-container">
+            <HBox alignment="CENTER_LEFT" spacing="15.0">
                <padding>
                   <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
                </padding>
-               <Label text="ID de Orden:" styleClass="filter-label">
-                  <font><Font name="System Bold" size="12.0"/></font>
+               <Label text="ID de Orden:">
                </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Ingrese el ID de la orden..." styleClass="search-field"/>
-               <Button text="🔍 Buscar" onAction="#call_Buscar" styleClass="search-button"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="🔄 Limpiar" styleClass="clear-button"/>
+               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Ingrese el ID de la orden..."/>
+               <Button text="Buscar" onAction="#call_Buscar"/>
+               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
             </HBox>
          </VBox>
 
-         <VBox VBox.vgrow="ALWAYS" styleClass="table-section">
+         <VBox VBox.vgrow="ALWAYS">
             <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="📋 Lista de Envíos" styleClass="section-title">
-                  <font><Font name="System Bold" size="16.0"/></font>
+               <Label text="Lista de Envíos">
                </Label>
             </HBox>
-            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS" styleClass="modern-table">
+            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
-                  <TableColumn fx:id="col_id" prefWidth="60.0" text="ID" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_orden" prefWidth="80.0" text="Orden" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_id" prefWidth="60.0" text="ID"/>
+                  <TableColumn fx:id="col_orden" prefWidth="80.0" text="Orden"/>
                   <TableColumn fx:id="col_direccion" prefWidth="200.0" text="Dirección de Entrega"/>
                   <TableColumn fx:id="col_empresa" prefWidth="120.0" text="Empresa"/>
-                  <TableColumn fx:id="col_tracking" prefWidth="130.0" text="Código Tracking" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_envio" prefWidth="110.0" text="Fecha Envío" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_estimada" prefWidth="110.0" text="Fecha Estimada" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_entrega" prefWidth="110.0" text="Fecha Entrega" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_tracking" prefWidth="130.0" text="Código Tracking"/>
+                  <TableColumn fx:id="col_envio" prefWidth="110.0" text="Fecha Envío"/>
+                  <TableColumn fx:id="col_estimada" prefWidth="110.0" text="Fecha Estimada"/>
+                  <TableColumn fx:id="col_entrega" prefWidth="110.0" text="Fecha Entrega"/>
                </columns>
                <columnResizePolicy>
                   <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
@@ -65,25 +61,17 @@
    </center>
 
    <bottom>
-      <VBox styleClass="footer-section">
+      <VBox>
          <Separator/>
-         <HBox alignment="CENTER_RIGHT" spacing="10.0" styleClass="action-bar">
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
             <padding>
                <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
             </padding>
             <Region HBox.hgrow="ALWAYS"/>
-            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" styleClass="primary-button">
-               <graphic><Label text="➕ Nuevo"/></graphic>
-            </Button>
-            <Button fx:id="btn_Editar" onAction="#call_Editar" styleClass="secondary-button">
-               <graphic><Label text="✏️ Editar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Borrar" onAction="#call_Borrar" styleClass="danger-button">
-               <graphic><Label text="🗑️ Eliminar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" styleClass="default-button">
-               <graphic><Label text="❌ Cerrar"/></graphic>
-            </Button>
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Eliminar"/>
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
          </HBox>
       </VBox>
    </bottom>

--- a/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
+++ b/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
@@ -79,7 +79,7 @@ public class Lst_Envios_GuiController implements Initializable {
         try{
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/EnviosGui/Mnt_Envios_Gui.fxml"));
-            stage.setTitle("Mantenimiento Envíos");
+            stage.setTitle("Formulario de Mantenimiento de Envíos");
             stage.setScene(new Scene(root));
             stage.showAndWait();
             call_Buscar();
@@ -97,7 +97,7 @@ public class Lst_Envios_GuiController implements Initializable {
             }
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/EnviosGui/Mnt_Envios_Gui.fxml"));
-            stage.setTitle("Mantenimiento Envíos");
+            stage.setTitle("Formulario de Mantenimiento de Envíos");
             stage.setScene(new Scene(root));
             stage.setUserData(dto);
             stage.showAndWait();

--- a/src/proyectobd/EnviosGui/Mnt_Envios_Gui.fxml
+++ b/src/proyectobd/EnviosGui/Mnt_Envios_Gui.fxml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.*?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.EnviosGui.Mnt_Envios_GuiController">
+<AnchorPane fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.EnviosGui.Mnt_Envios_GuiController">
     <children>
-        <Pane prefHeight="50.0" prefWidth="800.0" styleClass="header-pane">
+        <Pane prefHeight="50.0" prefWidth="800.0">
             <children>
-                <Label layoutX="240.0" layoutY="12.0" text="Mantenimiento Envíos" styleClass="header-label" />
+                <Label layoutX="240.0" layoutY="12.0" text="Formulario de Mantenimiento de Envíos" />
             </children>
         </Pane>
         <TitledPane layoutY="39.0" prefHeight="350.0" prefWidth="800.0" text="Detalles" animated="false">
@@ -39,8 +40,8 @@
             <content>
                 <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
                     <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" styleClass="action-button" />
-                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" styleClass="action-button" />
+                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
+                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
                     </children>
                 </AnchorPane>
             </content>

--- a/src/proyectobd/ImagenesProductoGui/Lst_ImagenesProducto_Gui.fxml
+++ b/src/proyectobd/ImagenesProductoGui/Lst_ImagenesProducto_Gui.fxml
@@ -4,12 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane prefHeight="700.0" prefWidth="1000.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ImagenesProductoGui.Lst_ImagenesProducto_GuiController">
+<BorderPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ImagenesProductoGui.Lst_ImagenesProducto_GuiController">
    <top>
-      <VBox styleClass="header-section">
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-pane">
-            <Label text="🖼️ Gestión de Imágenes" styleClass="header-title">
-               <font><Font name="System Bold" size="24.0"/></font>
+      <VBox>
+         <HBox alignment="CENTER" prefHeight="60.0">
+            <Label text="Panel de Gestión de Imágenes de Producto">
             </Label>
          </HBox>
          <Separator/>
@@ -17,40 +16,37 @@
    </top>
 
    <center>
-      <VBox spacing="10.0" styleClass="content-area">
+      <VBox spacing="10.0">
          <padding>
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox styleClass="filter-section">
-            <Label text="🔍 Filtros de Búsqueda" styleClass="section-title">
-               <font><Font name="System Bold" size="16.0"/></font>
+         <VBox>
+            <Label text="Filtros de Búsqueda">
             </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0" styleClass="filter-container">
+            <HBox alignment="CENTER_LEFT" spacing="15.0">
                <padding>
                   <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
                </padding>
-               <Label text="Producto ID:" styleClass="filter-label">
-                  <font><Font name="System Bold" size="12.0"/></font>
+               <Label text="Producto ID:">
                </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..." styleClass="search-field"/>
-               <Button text="🔍 Buscar" onAction="#call_Buscar" styleClass="search-button"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="🔄 Limpiar" styleClass="clear-button"/>
+               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
+               <Button text="Buscar" onAction="#call_Buscar"/>
+               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
             </HBox>
          </VBox>
 
-         <VBox VBox.vgrow="ALWAYS" styleClass="table-section">
+         <VBox VBox.vgrow="ALWAYS">
             <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="📋 Lista de Imágenes" styleClass="section-title">
-                  <font><Font name="System Bold" size="16.0"/></font>
+               <Label text="Lista de Imágenes">
                </Label>
             </HBox>
-            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS" styleClass="modern-table">
+            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
-                  <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_producto" prefWidth="75.0" text="Producto" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>
+                  <TableColumn fx:id="col_producto" prefWidth="75.0" text="Producto"/>
                   <TableColumn fx:id="col_url" prefWidth="250.0" text="URL"/>
-                  <TableColumn fx:id="col_principal" prefWidth="75.0" text="Principal" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_principal" prefWidth="75.0" text="Principal"/>
                </columns>
                <columnResizePolicy>
                   <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
@@ -61,25 +57,17 @@
    </center>
 
    <bottom>
-      <VBox styleClass="footer-section">
+      <VBox>
          <Separator/>
-         <HBox alignment="CENTER_RIGHT" spacing="10.0" styleClass="action-bar">
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
             <padding>
                <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
             </padding>
             <Region HBox.hgrow="ALWAYS"/>
-            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" styleClass="primary-button">
-               <graphic><Label text="➕ Nuevo"/></graphic>
-            </Button>
-            <Button fx:id="btn_Editar" onAction="#call_Editar" styleClass="secondary-button">
-               <graphic><Label text="✏️ Editar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Borrar" onAction="#call_Borrar" styleClass="danger-button">
-               <graphic><Label text="🗑️ Borrar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" styleClass="default-button">
-               <graphic><Label text="❌ Cerrar"/></graphic>
-            </Button>
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
          </HBox>
       </VBox>
    </bottom>

--- a/src/proyectobd/ImagenesProductoGui/Lst_ImagenesProducto_GuiController.java
+++ b/src/proyectobd/ImagenesProductoGui/Lst_ImagenesProducto_GuiController.java
@@ -75,7 +75,7 @@ public class Lst_ImagenesProducto_GuiController implements Initializable {
         try{
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Imágenes");
+            stage.setTitle("Formulario de Mantenimiento de Imágenes de Producto");
             stage.setScene(new Scene(root));
             stage.showAndWait();
             call_CargarDatos();
@@ -93,7 +93,7 @@ public class Lst_ImagenesProducto_GuiController implements Initializable {
             }
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Imágenes");
+            stage.setTitle("Formulario de Mantenimiento de Imágenes de Producto");
             stage.setScene(new Scene(root));
             stage.setUserData(dto);
             stage.showAndWait();

--- a/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml
+++ b/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml
@@ -4,11 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ImagenesProductoGui.Mnt_ImagenesProducto_GuiController">
+<AnchorPane fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ImagenesProductoGui.Mnt_ImagenesProducto_GuiController">
     <children>
-        <Pane prefHeight="50.0" prefWidth="600.0" styleClass="header-pane">
+        <Pane prefHeight="50.0" prefWidth="600.0">
             <children>
-                <Label layoutX="150.0" layoutY="12.0" text="Mantenimiento de Imágenes" styleClass="header-label" />
+                <Label layoutX="150.0" layoutY="12.0" text="Formulario de Mantenimiento de Imágenes de Producto" />
             </children>
         </Pane>
         <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
@@ -31,8 +31,8 @@
             <content>
                 <AnchorPane>
                     <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" styleClass="action-button" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" styleClass="action-button" />
+                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
+                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
                     </children>
                 </AnchorPane>
             </content>

--- a/src/proyectobd/ListasDeseosGui/Mnt_ListasDeseos_Gui.fxml
+++ b/src/proyectobd/ListasDeseosGui/Mnt_ListasDeseos_Gui.fxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.*?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 

--- a/src/proyectobd/OfertasGui/Lst_Ofertas_Gui.fxml
+++ b/src/proyectobd/OfertasGui/Lst_Ofertas_Gui.fxml
@@ -4,12 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane prefHeight="700.0" prefWidth="1000.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OfertasGui.Lst_Ofertas_GuiController">
+<BorderPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OfertasGui.Lst_Ofertas_GuiController">
    <top>
-      <VBox styleClass="header-section">
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-pane">
-            <Label text="💰 Gestión de Ofertas" styleClass="header-title">
-               <font><Font name="System Bold" size="24.0"/></font>
+      <VBox>
+         <HBox alignment="CENTER" prefHeight="60.0">
+            <Label text="Panel de Gestión de Ofertas Promocionales">
             </Label>
          </HBox>
          <Separator/>
@@ -17,41 +16,38 @@
    </top>
 
    <center>
-      <VBox spacing="10.0" styleClass="content-area">
+      <VBox spacing="10.0">
          <padding>
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox styleClass="filter-section">
-            <Label text="🔍 Filtros de Búsqueda" styleClass="section-title">
-               <font><Font name="System Bold" size="16.0"/></font>
+         <VBox>
+            <Label text="Filtros de Búsqueda">
             </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0" styleClass="filter-container">
+            <HBox alignment="CENTER_LEFT" spacing="15.0">
                <padding>
                   <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
                </padding>
-               <Label text="Variante ID:" styleClass="filter-label">
-                  <font><Font name="System Bold" size="12.0"/></font>
+               <Label text="Variante ID:">
                </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..." styleClass="search-field"/>
-               <Button text="🔍 Buscar" onAction="#call_Buscar" styleClass="search-button"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="🔄 Limpiar" styleClass="clear-button"/>
+               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
+               <Button text="Buscar" onAction="#call_Buscar"/>
+               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
             </HBox>
          </VBox>
 
-         <VBox VBox.vgrow="ALWAYS" styleClass="table-section">
+         <VBox VBox.vgrow="ALWAYS">
             <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="📋 Lista de Ofertas" styleClass="section-title">
-                  <font><Font name="System Bold" size="16.0"/></font>
+               <Label text="Lista de Ofertas">
                </Label>
             </HBox>
-            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS" styleClass="modern-table">
+            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
-                  <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_precio" prefWidth="75.0" text="Descuento" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_inicio" prefWidth="100.0" text="Inicio" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_fin" prefWidth="100.0" text="Fin" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>
+                  <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante"/>
+                  <TableColumn fx:id="col_precio" prefWidth="75.0" text="Descuento"/>
+                  <TableColumn fx:id="col_inicio" prefWidth="100.0" text="Inicio"/>
+                  <TableColumn fx:id="col_fin" prefWidth="100.0" text="Fin"/>
                </columns>
                <columnResizePolicy>
                   <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
@@ -62,25 +58,17 @@
    </center>
 
    <bottom>
-      <VBox styleClass="footer-section">
+      <VBox>
          <Separator/>
-         <HBox alignment="CENTER_RIGHT" spacing="10.0" styleClass="action-bar">
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
             <padding>
                <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
             </padding>
             <Region HBox.hgrow="ALWAYS"/>
-            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" styleClass="primary-button">
-               <graphic><Label text="➕ Nuevo"/></graphic>
-            </Button>
-            <Button fx:id="btn_Editar" onAction="#call_Editar" styleClass="secondary-button">
-               <graphic><Label text="✏️ Editar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Borrar" onAction="#call_Borrar" styleClass="danger-button">
-               <graphic><Label text="🗑️ Borrar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" styleClass="default-button">
-               <graphic><Label text="❌ Cerrar"/></graphic>
-            </Button>
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
          </HBox>
       </VBox>
    </bottom>

--- a/src/proyectobd/OfertasGui/Lst_Ofertas_GuiController.java
+++ b/src/proyectobd/OfertasGui/Lst_Ofertas_GuiController.java
@@ -78,7 +78,7 @@ public class Lst_Ofertas_GuiController implements Initializable {
         try{
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/OfertasGui/Mnt_Ofertas_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Ofertas");
+            stage.setTitle("Formulario de Mantenimiento de Ofertas");
             stage.setScene(new Scene(root));
             stage.showAndWait();
             call_CargarDatos();
@@ -96,7 +96,7 @@ public class Lst_Ofertas_GuiController implements Initializable {
             }
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/OfertasGui/Mnt_Ofertas_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Ofertas");
+            stage.setTitle("Formulario de Mantenimiento de Ofertas");
             stage.setScene(new Scene(root));
             stage.setUserData(dto);
             stage.showAndWait();

--- a/src/proyectobd/OfertasGui/Mnt_Ofertas_Gui.fxml
+++ b/src/proyectobd/OfertasGui/Mnt_Ofertas_Gui.fxml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.*?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OfertasGui.Mnt_Ofertas_GuiController">
+<AnchorPane fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OfertasGui.Mnt_Ofertas_GuiController">
     <children>
-        <Pane prefHeight="50.0" prefWidth="600.0" styleClass="header-pane">
+        <Pane prefHeight="50.0" prefWidth="600.0">
             <children>
-                <Label layoutX="190.0" layoutY="12.0" text="Mantenimiento de Ofertas" styleClass="header-label" />
+                <Label layoutX="190.0" layoutY="12.0" text="Formulario de Mantenimiento de Ofertas" />
             </children>
         </Pane>
         <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
@@ -33,8 +34,8 @@
             <content>
                 <AnchorPane>
                     <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" styleClass="action-button" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" styleClass="action-button" />
+                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
+                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
                     </children>
                 </AnchorPane>
             </content>

--- a/src/proyectobd/OrdenesGui/Mnt_Ordenes_Gui.fxml
+++ b/src/proyectobd/OrdenesGui/Mnt_Ordenes_Gui.fxml
@@ -5,6 +5,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.text.Font?>

--- a/src/proyectobd/PagosGui/Mnt_Pagos_Gui.fxml
+++ b/src/proyectobd/PagosGui/Mnt_Pagos_Gui.fxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.*?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 

--- a/src/proyectobd/ResenasGui/Lst_Resenas_Gui.fxml
+++ b/src/proyectobd/ResenasGui/Lst_Resenas_Gui.fxml
@@ -4,12 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane prefHeight="700.0" prefWidth="1000.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ResenasGui.Lst_Resenas_GuiController">
+<BorderPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ResenasGui.Lst_Resenas_GuiController">
    <top>
-      <VBox styleClass="header-section">
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-pane">
-            <Label text="⭐ Gestión de Reseñas" styleClass="header-title">
-               <font><Font name="System Bold" size="24.0"/></font>
+      <VBox>
+         <HBox alignment="CENTER" prefHeight="60.0">
+            <Label text="Panel de Gestión de Reseñas">
             </Label>
          </HBox>
          <Separator/>
@@ -17,40 +16,37 @@
    </top>
 
    <center>
-      <VBox spacing="10.0" styleClass="content-area">
+      <VBox spacing="10.0">
          <padding>
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox styleClass="filter-section">
-            <Label text="🔍 Filtros de Búsqueda" styleClass="section-title">
-               <font><Font name="System Bold" size="16.0"/></font>
+         <VBox>
+            <Label text="Filtros de Búsqueda">
             </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0" styleClass="filter-container">
+            <HBox alignment="CENTER_LEFT" spacing="15.0">
                <padding>
                   <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
                </padding>
-               <Label text="ID de Reseña:" styleClass="filter-label">
-                  <font><Font name="System Bold" size="12.0"/></font>
+               <Label text="ID de Reseña:">
                </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..." styleClass="search-field"/>
-               <Button text="🔍 Buscar" onAction="#call_Buscar" styleClass="search-button"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="🔄 Limpiar" styleClass="clear-button"/>
+               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
+               <Button text="Buscar" onAction="#call_Buscar"/>
+               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
             </HBox>
          </VBox>
 
-         <VBox VBox.vgrow="ALWAYS" styleClass="table-section">
+         <VBox VBox.vgrow="ALWAYS">
             <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="📋 Lista de Reseñas" styleClass="section-title">
-                  <font><Font name="System Bold" size="16.0"/></font>
+               <Label text="Lista de Reseñas">
                </Label>
             </HBox>
-            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS" styleClass="modern-table">
+            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
-                  <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_producto" prefWidth="75.0" text="Producto" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_rating" prefWidth="75.0" text="Rating" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
+                  <TableColumn fx:id="col_producto" prefWidth="75.0" text="Producto"/>
+                  <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario"/>
+                  <TableColumn fx:id="col_rating" prefWidth="75.0" text="Rating"/>
                   <TableColumn fx:id="col_fecha" prefWidth="150.0" text="Fecha"/>
                </columns>
                <columnResizePolicy>
@@ -62,25 +58,17 @@
    </center>
 
    <bottom>
-      <VBox styleClass="footer-section">
+      <VBox>
          <Separator/>
-         <HBox alignment="CENTER_RIGHT" spacing="10.0" styleClass="action-bar">
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
             <padding>
                <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
             </padding>
             <Region HBox.hgrow="ALWAYS"/>
-            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" styleClass="primary-button">
-               <graphic><Label text="➕ Nuevo"/></graphic>
-            </Button>
-            <Button fx:id="btn_Editar" onAction="#call_Editar" styleClass="secondary-button">
-               <graphic><Label text="✏️ Editar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Borrar" onAction="#call_Borrar" styleClass="danger-button">
-               <graphic><Label text="🗑️ Borrar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" styleClass="default-button">
-               <graphic><Label text="❌ Cerrar"/></graphic>
-            </Button>
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
          </HBox>
       </VBox>
    </bottom>

--- a/src/proyectobd/ResenasGui/Lst_Resenas_GuiController.java
+++ b/src/proyectobd/ResenasGui/Lst_Resenas_GuiController.java
@@ -78,7 +78,7 @@ public class Lst_Resenas_GuiController implements Initializable {
         try{
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/ResenasGui/Mnt_Resenas_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Reseñas");
+            stage.setTitle("Formulario de Mantenimiento de Reseñas");
             stage.setScene(new Scene(root));
             stage.showAndWait();
             call_CargarDatos();
@@ -96,7 +96,7 @@ public class Lst_Resenas_GuiController implements Initializable {
             }
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/ResenasGui/Mnt_Resenas_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Reseñas");
+            stage.setTitle("Formulario de Mantenimiento de Reseñas");
             stage.setScene(new Scene(root));
             stage.setUserData(dto);
             stage.showAndWait();

--- a/src/proyectobd/ResenasGui/Mnt_Resenas_Gui.fxml
+++ b/src/proyectobd/ResenasGui/Mnt_Resenas_Gui.fxml
@@ -5,15 +5,16 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ResenasGui.Mnt_Resenas_GuiController">
+<AnchorPane fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ResenasGui.Mnt_Resenas_GuiController">
     <children>
-        <Pane prefHeight="50.0" prefWidth="800.0" styleClass="header-pane">
+        <Pane prefHeight="50.0" prefWidth="800.0">
             <children>
-                <Label layoutX="240.0" layoutY="12.0" text="Mantenimiento de Reseñas" styleClass="header-label" />
+                <Label layoutX="240.0" layoutY="12.0" text="Formulario de Mantenimiento de Reseñas" />
             </children>
         </Pane>
         <TitledPane layoutY="39.0" prefHeight="300.0" prefWidth="800.0" text="Detalles del Registro" animated="false">
@@ -40,8 +41,8 @@
             <content>
                 <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
                     <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" styleClass="action-button" />
-                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" styleClass="action-button" />
+                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
+                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
                     </children>
                 </AnchorPane>
             </content>

--- a/src/proyectobd/VarianteProductoGui/Lst_VariantesProducto_Gui.fxml
+++ b/src/proyectobd/VarianteProductoGui/Lst_VariantesProducto_Gui.fxml
@@ -4,12 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane prefHeight="700.0" prefWidth="1000.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VarianteProductoGui.Lst_VariantesProducto_GuiController">
+<BorderPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VarianteProductoGui.Lst_VariantesProducto_GuiController">
    <top>
-      <VBox styleClass="header-section">
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-pane">
-            <Label text="🛍️ Gestión de Variantes" styleClass="header-title">
-               <font><Font name="System Bold" size="24.0"/></font>
+      <VBox>
+         <HBox alignment="CENTER" prefHeight="60.0">
+            <Label text="Panel de Gestión de Variantes de Producto">
             </Label>
          </HBox>
          <Separator/>
@@ -17,41 +16,38 @@
    </top>
 
    <center>
-      <VBox spacing="10.0" styleClass="content-area">
+      <VBox spacing="10.0">
          <padding>
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox styleClass="filter-section">
-            <Label text="🔍 Filtros de Búsqueda" styleClass="section-title">
-               <font><Font name="System Bold" size="16.0"/></font>
+         <VBox>
+            <Label text="Filtros de Búsqueda">
             </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0" styleClass="filter-container">
+            <HBox alignment="CENTER_LEFT" spacing="15.0">
                <padding>
                   <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
                </padding>
-               <Label text="Producto ID:" styleClass="filter-label">
-                  <font><Font name="System Bold" size="12.0"/></font>
+               <Label text="Producto ID:">
                </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..." styleClass="search-field"/>
-               <Button text="🔍 Buscar" onAction="#call_Buscar" styleClass="search-button"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="🔄 Limpiar" styleClass="clear-button"/>
+               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
+               <Button text="Buscar" onAction="#call_Buscar"/>
+               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
             </HBox>
          </VBox>
 
-         <VBox VBox.vgrow="ALWAYS" styleClass="table-section">
+         <VBox VBox.vgrow="ALWAYS">
             <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="📋 Lista de Variantes" styleClass="section-title">
-                  <font><Font name="System Bold" size="16.0"/></font>
+               <Label text="Lista de Variantes">
                </Label>
             </HBox>
-            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS" styleClass="modern-table">
+            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
-                  <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_producto" prefWidth="75.0" text="Producto" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>
+                  <TableColumn fx:id="col_producto" prefWidth="75.0" text="Producto"/>
                   <TableColumn fx:id="col_sku" prefWidth="150.0" text="SKU"/>
-                  <TableColumn fx:id="col_precio" prefWidth="75.0" text="Precio" styleClass="table-column-center"/>
-                  <TableColumn fx:id="col_stock" prefWidth="75.0" text="Stock" styleClass="table-column-center"/>
+                  <TableColumn fx:id="col_precio" prefWidth="75.0" text="Precio"/>
+                  <TableColumn fx:id="col_stock" prefWidth="75.0" text="Stock"/>
                </columns>
                <columnResizePolicy>
                   <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
@@ -62,25 +58,17 @@
    </center>
 
    <bottom>
-      <VBox styleClass="footer-section">
+      <VBox>
          <Separator/>
-         <HBox alignment="CENTER_RIGHT" spacing="10.0" styleClass="action-bar">
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
             <padding>
                <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
             </padding>
             <Region HBox.hgrow="ALWAYS"/>
-            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" styleClass="primary-button">
-               <graphic><Label text="➕ Nuevo"/></graphic>
-            </Button>
-            <Button fx:id="btn_Editar" onAction="#call_Editar" styleClass="secondary-button">
-               <graphic><Label text="✏️ Editar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Borrar" onAction="#call_Borrar" styleClass="danger-button">
-               <graphic><Label text="🗑️ Borrar"/></graphic>
-            </Button>
-            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" styleClass="default-button">
-               <graphic><Label text="❌ Cerrar"/></graphic>
-            </Button>
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
          </HBox>
       </VBox>
    </bottom>

--- a/src/proyectobd/VarianteProductoGui/Lst_VariantesProducto_GuiController.java
+++ b/src/proyectobd/VarianteProductoGui/Lst_VariantesProducto_GuiController.java
@@ -77,7 +77,7 @@ public class Lst_VariantesProducto_GuiController implements Initializable {
         try{
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Variantes");
+            stage.setTitle("Formulario de Mantenimiento de Variantes de Producto");
             stage.setScene(new Scene(root));
             stage.showAndWait();
             call_CargarDatos();
@@ -95,7 +95,7 @@ public class Lst_VariantesProducto_GuiController implements Initializable {
             }
             Stage stage = new Stage();
             Parent root = FXMLLoader.load(getClass().getResource("/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_Gui.fxml"));
-            stage.setTitle("Mantenimiento de Variantes");
+            stage.setTitle("Formulario de Mantenimiento de Variantes de Producto");
             stage.setScene(new Scene(root));
             stage.setUserData(dto);
             stage.showAndWait();

--- a/src/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_Gui.fxml
+++ b/src/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_Gui.fxml
@@ -4,11 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" stylesheets="@../styles/app.css" styleClass="main-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VarianteProductoGui.Mnt_VariantesProducto_GuiController">
+<AnchorPane fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VarianteProductoGui.Mnt_VariantesProducto_GuiController">
     <children>
-        <Pane prefHeight="50.0" prefWidth="600.0" styleClass="header-pane">
+        <Pane prefHeight="50.0" prefWidth="600.0">
             <children>
-                <Label layoutX="170.0" layoutY="12.0" text="Mantenimiento de Variantes" styleClass="header-label" />
+                <Label layoutX="170.0" layoutY="12.0" text="Formulario de Mantenimiento de Variantes de Producto" />
             </children>
         </Pane>
         <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
@@ -33,8 +33,8 @@
             <content>
                 <AnchorPane>
                     <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" styleClass="action-button" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" styleClass="action-button" />
+                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
+                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
                     </children>
                 </AnchorPane>
             </content>


### PR DESCRIPTION
## Summary
- remove custom CSS classes and icons from maintenance and list views for coupons, reviews, shipments, product variants, product images and offers
- keep DatePicker imports
- refine titles for coupons, reviews, shipments, product variants, product images and offers modules

## Testing
- `ant -noinput jar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685098e70d108332baa473ebe8ee5d5d