### PR TITLE
Improve DAO error handling

### DIFF
--- a/src/dao/CarritoDAO.java
+++ b/src/dao/CarritoDAO.java
@@ -106,7 +106,11 @@ public class CarritoDAO {
             ps.setTimestamp(2, dto.getCreadoEn());
             ps.setInt(3, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información", "Carrito actualizado. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Carrito no encontrado");
+            }else{
+                fu.MostrarAlertas("Información", "Carrito actualizado. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
@@ -122,7 +126,11 @@ public class CarritoDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información", "Carrito eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Carrito no encontrado");
+            }else{
+                fu.MostrarAlertas("Información", "Carrito eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){

--- a/src/dao/CarritoDAO.java
+++ b/src/dao/CarritoDAO.java
@@ -22,7 +22,7 @@ public class CarritoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "verificar el usuario");
             return false;
         }
     }
@@ -43,7 +43,7 @@ public class CarritoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "listar carritos");
         }
         return lista;
     }
@@ -64,7 +64,7 @@ public class CarritoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "buscar carritos");
         }
         return lista;
     }
@@ -72,7 +72,7 @@ public class CarritoDAO {
     public int InsertarCarrito(CarritoDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "El usuario no existe");
+                fu.datosInvalidos("El usuario no existe");
                 return 0;
             }
             String sql = "INSERT INTO carritos(usuario_id, creado_en) VALUES(?,?)";
@@ -88,7 +88,7 @@ public class CarritoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "registrar el carrito");
             return 0;
         }
     }
@@ -96,7 +96,7 @@ public class CarritoDAO {
     public int ActualizarCarrito(CarritoDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "El usuario no existe");
+                fu.datosInvalidos("El usuario no existe");
                 return 0;
             }
             String sql = "UPDATE carritos SET usuario_id=?, creado_en=? WHERE id=?";
@@ -110,7 +110,7 @@ public class CarritoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "actualizar el carrito");
             return 0;
         }
     }
@@ -126,7 +126,7 @@ public class CarritoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "eliminar el carrito");
             return 0;
         }
     }

--- a/src/dao/CarritoItemDAO.java
+++ b/src/dao/CarritoItemDAO.java
@@ -22,7 +22,7 @@ public class CarritoItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class CarritoItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -60,7 +60,7 @@ public class CarritoItemDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -68,7 +68,7 @@ public class CarritoItemDAO {
     public int InsertarItem(CarritoItemDTO dto){
         try{
             if(!existeCarrito(dto.getCarritoId()) || !existeVariante(dto.getVarianteId())){
-                fu.MostrarAlertas("Datos inválidos", "Carrito o variante inexistente");
+                fu.datosInvalidos("Carrito o variante inexistente");
                 return 0;
             }
             String sql = "INSERT INTO carrito_items(carrito_id, variante_id, cantidad) VALUES(?,?,?)";
@@ -85,7 +85,7 @@ public class CarritoItemDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -93,7 +93,7 @@ public class CarritoItemDAO {
     public int ActualizarItem(CarritoItemDTO dto){
         try{
             if(!existeCarrito(dto.getCarritoId()) || !existeVariante(dto.getVarianteId())){
-                fu.MostrarAlertas("Datos inválidos", "Carrito o variante inexistente");
+                fu.datosInvalidos("Carrito o variante inexistente");
                 return 0;
             }
             String sql = "UPDATE carrito_items SET carrito_id=?, variante_id=?, cantidad=? WHERE id=?";
@@ -108,7 +108,7 @@ public class CarritoItemDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -124,7 +124,7 @@ public class CarritoItemDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/CarritoItemDAO.java
+++ b/src/dao/CarritoItemDAO.java
@@ -22,7 +22,7 @@ public class CarritoItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el carrito");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class CarritoItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la variante");
             return false;
         }
     }
@@ -60,7 +60,7 @@ public class CarritoItemDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar items de carrito");
         }
         return lista;
     }
@@ -85,7 +85,7 @@ public class CarritoItemDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "agregar el item");
             return 0;
         }
     }
@@ -104,11 +104,15 @@ public class CarritoItemDAO {
             ps.setInt(3, dto.getCantidad());
             ps.setInt(4, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información", "Item actualizado. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Item no encontrado");
+            }else{
+                fu.MostrarAlertas("Información", "Item actualizado. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar el item");
             return 0;
         }
     }
@@ -120,11 +124,15 @@ public class CarritoItemDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información", "Item eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Item no encontrado");
+            }else{
+                fu.MostrarAlertas("Información", "Item eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar el item");
             return 0;
         }
     }

--- a/src/dao/CategoriaDAO.java
+++ b/src/dao/CategoriaDAO.java
@@ -22,7 +22,7 @@ public class CategoriaDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "verificar la categoría");
             return false;
         }
     }
@@ -44,7 +44,7 @@ public class CategoriaDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "listar categorías");
         }
         return lista;
     }
@@ -66,7 +66,7 @@ public class CategoriaDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "buscar categorías");
         }
         return lista;
     }
@@ -74,7 +74,7 @@ public class CategoriaDAO {
     public int InsertarCategoria(CategoriaDTO dto){
         try{
             if(dto.getParentId()!=null && !existeCategoria(dto.getParentId())){
-                fu.MostrarAlertas("Datos inválidos","Categoría padre inexistente");
+                fu.datosInvalidos("Categoría padre inexistente");
                 return 0;
             }
             String sql = "INSERT INTO categorias(nombre, parent_id) VALUES(?,?)";
@@ -90,7 +90,7 @@ public class CategoriaDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "registrar la categoría");
             return 0;
         }
     }
@@ -98,7 +98,7 @@ public class CategoriaDAO {
     public int ActualizarCategoria(CategoriaDTO dto){
         try{
             if(dto.getParentId()!=null && !existeCategoria(dto.getParentId())){
-                fu.MostrarAlertas("Datos inválidos","Categoría padre inexistente");
+                fu.datosInvalidos("Categoría padre inexistente");
                 return 0;
             }
             String sql = "UPDATE categorias SET nombre=?, parent_id=? WHERE id=?";
@@ -112,7 +112,7 @@ public class CategoriaDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "actualizar la categoría");
             return 0;
         }
     }
@@ -128,7 +128,7 @@ public class CategoriaDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "eliminar la categoría");
             return 0;
         }
     }

--- a/src/dao/CuponDAO.java
+++ b/src/dao/CuponDAO.java
@@ -29,7 +29,7 @@ public class CuponDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return cupones;
     }
@@ -53,7 +53,7 @@ public class CuponDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return cupones;
     }
@@ -77,7 +77,7 @@ public class CuponDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -97,7 +97,7 @@ public class CuponDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -113,7 +113,7 @@ public class CuponDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/CuponDAO.java
+++ b/src/dao/CuponDAO.java
@@ -29,7 +29,7 @@ public class CuponDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar cupones");
         }
         return cupones;
     }
@@ -53,7 +53,7 @@ public class CuponDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "buscar cupones");
         }
         return cupones;
     }
@@ -77,7 +77,7 @@ public class CuponDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar el cupón");
             return 0;
         }
     }
@@ -93,11 +93,15 @@ public class CuponDAO {
             ps.setInt(4, dto.getUsoMaximo());
             ps.setInt(5, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Cupón actualizado. Registros modificados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Cupón no encontrado");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Cupón actualizado. Registros modificados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar el cupón");
             return 0;
         }
     }
@@ -109,11 +113,15 @@ public class CuponDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Cupón eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Cupón no encontrado");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Cupón eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar el cupón");
             return 0;
         }
     }

--- a/src/dao/DireccionDAO.java
+++ b/src/dao/DireccionDAO.java
@@ -22,7 +22,7 @@ public class DireccionDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -48,7 +48,7 @@ public class DireccionDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -74,7 +74,7 @@ public class DireccionDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -82,7 +82,7 @@ public class DireccionDAO {
     public int InsertarDireccion(DireccionDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "El usuario no existe");
+                fu.datosInvalidos("El usuario no existe");
                 return 0;
             }
             String sql = "INSERT INTO direcciones(usuario_id, alias, direccion, ciudad, provincia, codigo_postal, telefono_contacto) VALUES(?,?,?,?,?,?,?)";
@@ -103,7 +103,7 @@ public class DireccionDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -111,7 +111,7 @@ public class DireccionDAO {
     public int ActualizarDireccion(DireccionDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "El usuario no existe");
+                fu.datosInvalidos("El usuario no existe");
                 return 0;
             }
             String sql = "UPDATE direcciones SET usuario_id=?, alias=?, direccion=?, ciudad=?, provincia=?, codigo_postal=?, telefono_contacto=? WHERE id=?";
@@ -130,7 +130,7 @@ public class DireccionDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -146,7 +146,7 @@ public class DireccionDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/DireccionDAO.java
+++ b/src/dao/DireccionDAO.java
@@ -22,7 +22,7 @@ public class DireccionDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el usuario");
             return false;
         }
     }
@@ -48,7 +48,7 @@ public class DireccionDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar direcciones");
         }
         return lista;
     }
@@ -74,7 +74,7 @@ public class DireccionDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "buscar direcciones");
         }
         return lista;
     }
@@ -103,7 +103,7 @@ public class DireccionDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar la dirección");
             return 0;
         }
     }
@@ -126,11 +126,15 @@ public class DireccionDAO {
             ps.setString(7, dto.getTelefonoContacto());
             ps.setInt(8, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información", "Dirección actualizada. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Dirección no encontrada");
+            }else{
+                fu.MostrarAlertas("Información", "Dirección actualizada. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar la dirección");
             return 0;
         }
     }
@@ -142,11 +146,15 @@ public class DireccionDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información", "Dirección eliminada. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Dirección no encontrada");
+            }else{
+                fu.MostrarAlertas("Información", "Dirección eliminada. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar la dirección");
             return 0;
         }
     }

--- a/src/dao/EnvioDAO.java
+++ b/src/dao/EnvioDAO.java
@@ -22,7 +22,7 @@ public class EnvioDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la orden");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class EnvioDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la dirección");
             return false;
         }
     }
@@ -64,7 +64,7 @@ public class EnvioDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar envíos");
         }
         return lista;
     }
@@ -93,7 +93,7 @@ public class EnvioDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar el envío");
             return 0;
         }
     }
@@ -116,11 +116,15 @@ public class EnvioDAO {
             ps.setTimestamp(7, dto.getFechaEntregaReal());
             ps.setInt(8, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información", "Envío actualizado. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Envío no encontrado");
+            }else{
+                fu.MostrarAlertas("Información", "Envío actualizado. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar el envío");
             return 0;
         }
     }
@@ -132,11 +136,15 @@ public class EnvioDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información", "Envío eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Envío no encontrado");
+            }else{
+                fu.MostrarAlertas("Información", "Envío eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar el envío");
             return 0;
         }
     }

--- a/src/dao/EnvioDAO.java
+++ b/src/dao/EnvioDAO.java
@@ -22,7 +22,7 @@ public class EnvioDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class EnvioDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -64,7 +64,7 @@ public class EnvioDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -72,7 +72,7 @@ public class EnvioDAO {
     public int InsertarEnvio(EnvioDTO dto){
         try{
             if(!existeOrden(dto.getOrdenId()) || !existeDireccion(dto.getDireccionId())){
-                fu.MostrarAlertas("Datos inválidos", "Orden o dirección inexistente");
+                fu.datosInvalidos("Orden o dirección inexistente");
                 return 0;
             }
             String sql = "INSERT INTO envios(orden_id, direccion_id, empresa_envio, codigo_tracking, fecha_envio, fecha_entrega_estimada, fecha_entrega_real) VALUES(?,?,?,?,?,?,?)";
@@ -93,7 +93,7 @@ public class EnvioDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -101,7 +101,7 @@ public class EnvioDAO {
     public int ActualizarEnvio(EnvioDTO dto){
         try{
             if(!existeOrden(dto.getOrdenId()) || !existeDireccion(dto.getDireccionId())){
-                fu.MostrarAlertas("Datos inválidos", "Orden o dirección inexistente");
+                fu.datosInvalidos("Orden o dirección inexistente");
                 return 0;
             }
             String sql = "UPDATE envios SET orden_id=?, direccion_id=?, empresa_envio=?, codigo_tracking=?, fecha_envio=?, fecha_entrega_estimada=?, fecha_entrega_real=? WHERE id=?";
@@ -120,7 +120,7 @@ public class EnvioDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -136,7 +136,7 @@ public class EnvioDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/ImagenProductoDAO.java
+++ b/src/dao/ImagenProductoDAO.java
@@ -22,7 +22,7 @@ public class ImagenProductoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -48,7 +48,7 @@ public class ImagenProductoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -56,7 +56,7 @@ public class ImagenProductoDAO {
     public int InsertarImagen(ImagenProductoDTO dto){
         try{
             if(!existeProducto(dto.getProductoId())){
-                fu.MostrarAlertas("Datos invalidos", "Producto inexistente");
+                fu.datosInvalidos("Producto inexistente");
                 return 0;
             }
             String sql = "INSERT INTO imagenes_producto(producto_id, url, es_principal) VALUES(?,?,?)";
@@ -73,7 +73,7 @@ public class ImagenProductoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -81,7 +81,7 @@ public class ImagenProductoDAO {
     public int ActualizarImagen(ImagenProductoDTO dto){
         try{
             if(!existeProducto(dto.getProductoId())){
-                fu.MostrarAlertas("Datos invalidos", "Producto inexistente");
+                fu.datosInvalidos("Producto inexistente");
                 return 0;
             }
             String sql = "UPDATE imagenes_producto SET producto_id=?, url=?, es_principal=? WHERE id=?";
@@ -96,7 +96,7 @@ public class ImagenProductoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -112,7 +112,7 @@ public class ImagenProductoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/ImagenProductoDAO.java
+++ b/src/dao/ImagenProductoDAO.java
@@ -22,7 +22,7 @@ public class ImagenProductoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el producto");
             return false;
         }
     }
@@ -48,7 +48,7 @@ public class ImagenProductoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar imágenes");
         }
         return lista;
     }
@@ -73,7 +73,7 @@ public class ImagenProductoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar la imagen");
             return 0;
         }
     }
@@ -92,11 +92,15 @@ public class ImagenProductoDAO {
             ps.setBoolean(3, dto.isEsPrincipal());
             ps.setInt(4, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Imagen actualizada. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Imagen no encontrada");
+            }else{
+                fu.MostrarAlertas("Informacion", "Imagen actualizada. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar la imagen");
             return 0;
         }
     }
@@ -108,11 +112,15 @@ public class ImagenProductoDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Imagen eliminada. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Imagen no encontrada");
+            }else{
+                fu.MostrarAlertas("Informacion", "Imagen eliminada. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar la imagen");
             return 0;
         }
     }

--- a/src/dao/ListaDeseoDAO.java
+++ b/src/dao/ListaDeseoDAO.java
@@ -22,7 +22,7 @@ public class ListaDeseoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el usuario");
             return false;
         }
     }
@@ -44,7 +44,7 @@ public class ListaDeseoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar listas de deseos");
         }
         return lista;
     }
@@ -69,7 +69,7 @@ public class ListaDeseoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar la lista");
             return 0;
         }
     }
@@ -88,11 +88,15 @@ public class ListaDeseoDAO {
             ps.setTimestamp(3, dto.getCreadoEn());
             ps.setInt(4, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Lista actualizada. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Lista no encontrada");
+            }else{
+                fu.MostrarAlertas("Informacion", "Lista actualizada. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar la lista");
             return 0;
         }
     }
@@ -104,11 +108,15 @@ public class ListaDeseoDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Lista eliminada. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Lista no encontrada");
+            }else{
+                fu.MostrarAlertas("Informacion", "Lista eliminada. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar la lista");
             return 0;
         }
     }

--- a/src/dao/ListaDeseoDAO.java
+++ b/src/dao/ListaDeseoDAO.java
@@ -22,7 +22,7 @@ public class ListaDeseoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -44,7 +44,7 @@ public class ListaDeseoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -52,7 +52,7 @@ public class ListaDeseoDAO {
     public int InsertarLista(ListaDeseoDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos invalidos", "Usuario inexistente");
+                fu.datosInvalidos("Usuario inexistente");
                 return 0;
             }
             String sql = "INSERT INTO listas_deseos(usuario_id, nombre, creado_en) VALUES(?,?,?)";
@@ -69,7 +69,7 @@ public class ListaDeseoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -77,7 +77,7 @@ public class ListaDeseoDAO {
     public int ActualizarLista(ListaDeseoDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos invalidos", "Usuario inexistente");
+                fu.datosInvalidos("Usuario inexistente");
                 return 0;
             }
             String sql = "UPDATE listas_deseos SET usuario_id=?, nombre=?, creado_en=? WHERE id=?";
@@ -92,7 +92,7 @@ public class ListaDeseoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -108,7 +108,7 @@ public class ListaDeseoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/ListaDeseoItemDAO.java
+++ b/src/dao/ListaDeseoItemDAO.java
@@ -22,7 +22,7 @@ public class ListaDeseoItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la lista");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class ListaDeseoItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la variante");
             return false;
         }
     }
@@ -60,7 +60,7 @@ public class ListaDeseoItemDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar items de lista");
         }
         return lista;
     }
@@ -85,7 +85,7 @@ public class ListaDeseoItemDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar el item");
             return 0;
         }
     }
@@ -104,11 +104,15 @@ public class ListaDeseoItemDAO {
             ps.setInt(3, dto.getCantidad());
             ps.setInt(4, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Item actualizado. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Item no encontrado");
+            }else{
+                fu.MostrarAlertas("Informacion", "Item actualizado. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar el item");
             return 0;
         }
     }
@@ -120,11 +124,15 @@ public class ListaDeseoItemDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Item eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Item no encontrado");
+            }else{
+                fu.MostrarAlertas("Informacion", "Item eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar el item");
             return 0;
         }
     }

--- a/src/dao/ListaDeseoItemDAO.java
+++ b/src/dao/ListaDeseoItemDAO.java
@@ -22,7 +22,7 @@ public class ListaDeseoItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class ListaDeseoItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -60,7 +60,7 @@ public class ListaDeseoItemDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -68,7 +68,7 @@ public class ListaDeseoItemDAO {
     public int InsertarItem(ListaDeseoItemDTO dto){
         try{
             if(!existeLista(dto.getListaDeseosId()) || !existeVariante(dto.getVarianteId())){
-                fu.MostrarAlertas("Datos invalidos", "Lista o variante inexistente");
+                fu.datosInvalidos("Lista o variante inexistente");
                 return 0;
             }
             String sql = "INSERT INTO lista_deseos_items(lista_deseos_id, variante_id, cantidad) VALUES(?,?,?)";
@@ -85,7 +85,7 @@ public class ListaDeseoItemDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -93,7 +93,7 @@ public class ListaDeseoItemDAO {
     public int ActualizarItem(ListaDeseoItemDTO dto){
         try{
             if(!existeLista(dto.getListaDeseosId()) || !existeVariante(dto.getVarianteId())){
-                fu.MostrarAlertas("Datos invalidos", "Lista o variante inexistente");
+                fu.datosInvalidos("Lista o variante inexistente");
                 return 0;
             }
             String sql = "UPDATE lista_deseos_items SET lista_deseos_id=?, variante_id=?, cantidad=? WHERE id=?";
@@ -108,7 +108,7 @@ public class ListaDeseoItemDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -124,7 +124,7 @@ public class ListaDeseoItemDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/OfertaDAO.java
+++ b/src/dao/OfertaDAO.java
@@ -22,7 +22,7 @@ public class OfertaDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -45,7 +45,7 @@ public class OfertaDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -53,7 +53,7 @@ public class OfertaDAO {
     public int InsertarOferta(OfertaDTO dto){
         try{
             if(!existeVariante(dto.getVarianteId())){
-                fu.MostrarAlertas("Datos invalidos", "Variante inexistente");
+                fu.datosInvalidos("Variante inexistente");
                 return 0;
             }
             String sql = "INSERT INTO ofertas(variante_id, precio_descuento, fecha_inicio, fecha_fin) VALUES(?,?,?,?)";
@@ -71,7 +71,7 @@ public class OfertaDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -79,7 +79,7 @@ public class OfertaDAO {
     public int ActualizarOferta(OfertaDTO dto){
         try{
             if(!existeVariante(dto.getVarianteId())){
-                fu.MostrarAlertas("Datos invalidos", "Variante inexistente");
+                fu.datosInvalidos("Variante inexistente");
                 return 0;
             }
             String sql = "UPDATE ofertas SET variante_id=?, precio_descuento=?, fecha_inicio=?, fecha_fin=? WHERE id=?";
@@ -95,7 +95,7 @@ public class OfertaDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -111,7 +111,7 @@ public class OfertaDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/OfertaDAO.java
+++ b/src/dao/OfertaDAO.java
@@ -22,7 +22,7 @@ public class OfertaDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la variante");
             return false;
         }
     }
@@ -45,7 +45,7 @@ public class OfertaDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar ofertas");
         }
         return lista;
     }
@@ -71,7 +71,7 @@ public class OfertaDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar la oferta");
             return 0;
         }
     }
@@ -91,11 +91,15 @@ public class OfertaDAO {
             ps.setTimestamp(4, dto.getFechaFin());
             ps.setInt(5, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Oferta actualizada. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Oferta no encontrada");
+            }else{
+                fu.MostrarAlertas("Informacion", "Oferta actualizada. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar la oferta");
             return 0;
         }
     }
@@ -107,11 +111,15 @@ public class OfertaDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Oferta eliminada. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Oferta no encontrada");
+            }else{
+                fu.MostrarAlertas("Informacion", "Oferta eliminada. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar la oferta");
             return 0;
         }
     }

--- a/src/dao/OrdenDAO.java
+++ b/src/dao/OrdenDAO.java
@@ -22,7 +22,7 @@ public class OrdenDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -46,7 +46,7 @@ public class OrdenDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return ordenes;
     }
@@ -71,7 +71,7 @@ public class OrdenDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return ordenes;
     }
@@ -79,7 +79,7 @@ public class OrdenDAO {
     public int InsertarOrden(OrdenDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "El usuario especificado no existe");
+                fu.datosInvalidos("El usuario especificado no existe");
                 return 0;
             }
             String sql = "INSERT INTO ordenes(usuario_id, estado, total_bruto, total_descuento, fecha_creacion) VALUES(?,?,?,?,?)";
@@ -100,7 +100,7 @@ public class OrdenDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -108,7 +108,7 @@ public class OrdenDAO {
     public int ActualizarOrden(OrdenDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "El usuario especificado no existe");
+                fu.datosInvalidos("El usuario especificado no existe");
                 return 0;
             }
             String sql = "UPDATE ordenes SET usuario_id=?, estado=?, total_bruto=?, total_descuento=?, fecha_creacion=? WHERE id=?";
@@ -125,7 +125,7 @@ public class OrdenDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -141,7 +141,7 @@ public class OrdenDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/OrdenDAO.java
+++ b/src/dao/OrdenDAO.java
@@ -22,7 +22,7 @@ public class OrdenDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el usuario");
             return false;
         }
     }
@@ -46,7 +46,7 @@ public class OrdenDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar órdenes");
         }
         return ordenes;
     }
@@ -71,7 +71,7 @@ public class OrdenDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "buscar órdenes");
         }
         return ordenes;
     }
@@ -100,7 +100,7 @@ public class OrdenDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar la orden");
             return 0;
         }
     }
@@ -121,11 +121,15 @@ public class OrdenDAO {
             ps.setTimestamp(5, dto.getFechaCreacion());
             ps.setInt(6, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Orden actualizada. Registros modificados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Orden no encontrada");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Orden actualizada. Registros modificados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar la orden");
             return 0;
         }
     }
@@ -137,11 +141,15 @@ public class OrdenDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Orden eliminada. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Orden no encontrada");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Orden eliminada. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar la orden");
             return 0;
         }
     }

--- a/src/dao/OrdenItemDAO.java
+++ b/src/dao/OrdenItemDAO.java
@@ -22,7 +22,7 @@ public class OrdenItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la orden");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class OrdenItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la variante");
             return false;
         }
     }
@@ -62,7 +62,7 @@ public class OrdenItemDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar items de orden");
         }
         return lista;
     }
@@ -89,7 +89,7 @@ public class OrdenItemDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar el item");
             return 0;
         }
     }
@@ -110,11 +110,15 @@ public class OrdenItemDAO {
             ps.setDouble(5, dto.getPrecioDescuento());
             ps.setInt(6, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Item actualizado. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Item no encontrado");
+            }else{
+                fu.MostrarAlertas("Informacion", "Item actualizado. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar el item");
             return 0;
         }
     }
@@ -126,11 +130,15 @@ public class OrdenItemDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Item eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Item no encontrado");
+            }else{
+                fu.MostrarAlertas("Informacion", "Item eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar el item");
             return 0;
         }
     }

--- a/src/dao/OrdenItemDAO.java
+++ b/src/dao/OrdenItemDAO.java
@@ -22,7 +22,7 @@ public class OrdenItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class OrdenItemDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -62,7 +62,7 @@ public class OrdenItemDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -70,7 +70,7 @@ public class OrdenItemDAO {
     public int InsertarItem(OrdenItemDTO dto){
         try{
             if(!existeOrden(dto.getOrdenId()) || !existeVariante(dto.getVarianteId())){
-                fu.MostrarAlertas("Datos invalidos", "Orden o variante inexistente");
+                fu.datosInvalidos("Orden o variante inexistente");
                 return 0;
             }
             String sql = "INSERT INTO orden_items(orden_id, variante_id, cantidad, precio_unitario, precio_descuento) VALUES(?,?,?,?,?)";
@@ -89,7 +89,7 @@ public class OrdenItemDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -97,7 +97,7 @@ public class OrdenItemDAO {
     public int ActualizarItem(OrdenItemDTO dto){
         try{
             if(!existeOrden(dto.getOrdenId()) || !existeVariante(dto.getVarianteId())){
-                fu.MostrarAlertas("Datos invalidos", "Orden o variante inexistente");
+                fu.datosInvalidos("Orden o variante inexistente");
                 return 0;
             }
             String sql = "UPDATE orden_items SET orden_id=?, variante_id=?, cantidad=?, precio_unitario=?, precio_descuento=? WHERE id=?";
@@ -114,7 +114,7 @@ public class OrdenItemDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -130,7 +130,7 @@ public class OrdenItemDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/PagoDAO.java
+++ b/src/dao/PagoDAO.java
@@ -22,7 +22,7 @@ public class PagoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la orden");
             return false;
         }
     }
@@ -45,7 +45,7 @@ public class PagoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar pagos");
         }
         return lista;
     }
@@ -71,7 +71,7 @@ public class PagoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar el pago");
             return 0;
         }
     }
@@ -91,11 +91,15 @@ public class PagoDAO {
             ps.setTimestamp(4, dto.getFechaPago());
             ps.setInt(5, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Pago actualizado. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Pago no encontrado");
+            }else{
+                fu.MostrarAlertas("Informacion", "Pago actualizado. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar el pago");
             return 0;
         }
     }
@@ -107,11 +111,15 @@ public class PagoDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Pago eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Pago no encontrado");
+            }else{
+                fu.MostrarAlertas("Informacion", "Pago eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar el pago");
             return 0;
         }
     }

--- a/src/dao/PagoDAO.java
+++ b/src/dao/PagoDAO.java
@@ -22,7 +22,7 @@ public class PagoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -45,7 +45,7 @@ public class PagoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -53,7 +53,7 @@ public class PagoDAO {
     public int InsertarPago(PagoDTO dto){
         try{
             if(!existeOrden(dto.getOrdenId())){
-                fu.MostrarAlertas("Datos invalidos", "Orden inexistente");
+                fu.datosInvalidos("Orden inexistente");
                 return 0;
             }
             String sql = "INSERT INTO pagos(orden_id, metodo_pago, monto, fecha_pago) VALUES(?,?,?,?)";
@@ -71,7 +71,7 @@ public class PagoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -79,7 +79,7 @@ public class PagoDAO {
     public int ActualizarPago(PagoDTO dto){
         try{
             if(!existeOrden(dto.getOrdenId())){
-                fu.MostrarAlertas("Datos invalidos", "Orden inexistente");
+                fu.datosInvalidos("Orden inexistente");
                 return 0;
             }
             String sql = "UPDATE pagos SET orden_id=?, metodo_pago=?, monto=?, fecha_pago=? WHERE id=?";
@@ -95,7 +95,7 @@ public class PagoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -111,7 +111,7 @@ public class PagoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/ProductoDAO.java
+++ b/src/dao/ProductoDAO.java
@@ -22,7 +22,7 @@ public class ProductoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el vendedor");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class ProductoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar la categoría");
             return false;
         }
     }
@@ -63,7 +63,7 @@ public class ProductoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar productos");
         }
         return productos;
     }
@@ -89,7 +89,7 @@ public class ProductoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "buscar productos");
         }
         return productos;
     }
@@ -119,7 +119,7 @@ public class ProductoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar el producto");
             return 0;
         }
     }
@@ -141,11 +141,15 @@ public class ProductoDAO {
             ps.setBoolean(6, dto.isActivo());
             ps.setInt(7, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Producto actualizado. Registros modificados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Producto no encontrado");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Producto actualizado. Registros modificados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar el producto");
             return 0;
         }
     }
@@ -157,11 +161,15 @@ public class ProductoDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Producto eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Producto no encontrado");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Producto eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar el producto");
             return 0;
         }
     }

--- a/src/dao/ProductoDAO.java
+++ b/src/dao/ProductoDAO.java
@@ -22,7 +22,7 @@ public class ProductoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class ProductoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -63,7 +63,7 @@ public class ProductoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return productos;
     }
@@ -89,7 +89,7 @@ public class ProductoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return productos;
     }
@@ -97,7 +97,7 @@ public class ProductoDAO {
     public int InsertarProducto(ProductoDTO dto){
         try{
             if(!existeVendedor(dto.getVendedorId()) || !existeCategoria(dto.getCategoriaId())){
-                fu.MostrarAlertas("Datos inválidos", "Verifique vendedor y categoría");
+                fu.datosInvalidos("Verifique vendedor y categoría");
                 return 0;
             }
             String sql = "INSERT INTO productos(vendedor_id, categoria_id, titulo, descripcion, creado_en, activo) VALUES(?,?,?,?,?,?)";
@@ -119,7 +119,7 @@ public class ProductoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -127,7 +127,7 @@ public class ProductoDAO {
     public int ActualizarProducto(ProductoDTO dto){
         try{
             if(!existeVendedor(dto.getVendedorId()) || !existeCategoria(dto.getCategoriaId())){
-                fu.MostrarAlertas("Datos inválidos", "Verifique vendedor y categoría");
+                fu.datosInvalidos("Verifique vendedor y categoría");
                 return 0;
             }
             String sql = "UPDATE productos SET vendedor_id=?, categoria_id=?, titulo=?, descripcion=?, creado_en=?, activo=? WHERE id=?";
@@ -145,7 +145,7 @@ public class ProductoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -161,7 +161,7 @@ public class ProductoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/ResenaDAO.java
+++ b/src/dao/ResenaDAO.java
@@ -22,7 +22,7 @@ public class ResenaDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class ResenaDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -62,7 +62,7 @@ public class ResenaDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return resenas;
     }
@@ -87,7 +87,7 @@ public class ResenaDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return resenas;
     }
@@ -95,7 +95,7 @@ public class ResenaDAO {
     public int InsertarResena(ResenaDTO dto){
         try{
             if(!existeProducto(dto.getProductoId()) || !existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "Verifique producto y usuario");
+                fu.datosInvalidos("Verifique producto y usuario");
                 return 0;
             }
             String sql = "INSERT INTO reseñas(producto_id, usuario_id, rating, comentario, fecha) VALUES(?,?,?,?,?)";
@@ -116,7 +116,7 @@ public class ResenaDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -124,7 +124,7 @@ public class ResenaDAO {
     public int ActualizarResena(ResenaDTO dto){
         try{
             if(!existeProducto(dto.getProductoId()) || !existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "Verifique producto y usuario");
+                fu.datosInvalidos("Verifique producto y usuario");
                 return 0;
             }
             String sql = "UPDATE reseñas SET producto_id=?, usuario_id=?, rating=?, comentario=?, fecha=? WHERE id=?";
@@ -141,7 +141,7 @@ public class ResenaDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -157,7 +157,7 @@ public class ResenaDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/ResenaDAO.java
+++ b/src/dao/ResenaDAO.java
@@ -22,7 +22,7 @@ public class ResenaDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el usuario");
             return false;
         }
     }
@@ -38,7 +38,7 @@ public class ResenaDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el producto");
             return false;
         }
     }
@@ -62,7 +62,7 @@ public class ResenaDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar reseñas");
         }
         return resenas;
     }
@@ -87,7 +87,7 @@ public class ResenaDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "buscar reseñas");
         }
         return resenas;
     }
@@ -116,7 +116,7 @@ public class ResenaDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar la reseña");
             return 0;
         }
     }
@@ -137,11 +137,15 @@ public class ResenaDAO {
             ps.setTimestamp(5, dto.getFecha());
             ps.setInt(6, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Reseña actualizada. Registros modificados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Reseña no encontrada");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Reseña actualizada. Registros modificados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar la reseña");
             return 0;
         }
     }
@@ -153,11 +157,15 @@ public class ResenaDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Reseña eliminada. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Reseña no encontrada");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Reseña eliminada. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar la reseña");
             return 0;
         }
     }

--- a/src/dao/RolDAO.java
+++ b/src/dao/RolDAO.java
@@ -26,7 +26,7 @@ public class RolDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.error("listar roles");
+            fu.errorSQL(ex, "listar roles");
         }
         return roles;
     }
@@ -46,7 +46,7 @@ public class RolDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.error("buscar roles");
+            fu.errorSQL(ex, "buscar roles");
         }
         return roles;
     }
@@ -67,7 +67,7 @@ public class RolDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.error("registrar el rol");
+            fu.errorSQL(ex, "registrar el rol");
             return 0;
         }
     }
@@ -84,7 +84,7 @@ public class RolDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.error("actualizar el rol");
+            fu.errorSQL(ex, "actualizar el rol");
             return 0;
         }
     }
@@ -100,7 +100,7 @@ public class RolDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.error("eliminar el rol");
+            fu.errorSQL(ex, "eliminar el rol");
             return 0;
         }
     }

--- a/src/dao/RolDAO.java
+++ b/src/dao/RolDAO.java
@@ -26,7 +26,7 @@ public class RolDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.error("listar roles");
         }
         return roles;
     }
@@ -46,7 +46,7 @@ public class RolDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.error("buscar roles");
         }
         return roles;
     }
@@ -67,7 +67,7 @@ public class RolDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.error("registrar el rol");
             return 0;
         }
     }
@@ -84,7 +84,7 @@ public class RolDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.error("actualizar el rol");
             return 0;
         }
     }
@@ -100,7 +100,7 @@ public class RolDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.error("eliminar el rol");
             return 0;
         }
     }

--- a/src/dao/UsuarioDAO.java
+++ b/src/dao/UsuarioDAO.java
@@ -47,7 +47,7 @@ public class UsuarioDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.error("listar usuarios");
         }
         return usuarios;
     }
@@ -76,7 +76,7 @@ public class UsuarioDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString()+"\n"+sql);
+            fu.error("buscar usuarios");
         }
         return usuarios;
     }
@@ -100,7 +100,7 @@ public class UsuarioDAO {
             ConnBD.CerrarConexionBD();
             return codigoInsertado;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.error("registrar el usuario");
             return 0;
         }
     }
@@ -120,7 +120,7 @@ public class UsuarioDAO {
             ConnBD.CerrarConexionBD();
             return registrosActualizados;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.error("actualizar el usuario");
             return 0;
         }
     }
@@ -136,7 +136,7 @@ public class UsuarioDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.error("eliminar el usuario");
             return 0;
         }
     }

--- a/src/dao/UsuarioDAO.java
+++ b/src/dao/UsuarioDAO.java
@@ -47,7 +47,7 @@ public class UsuarioDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.error("listar usuarios");
+            fu.errorSQL(ex, "listar usuarios");
         }
         return usuarios;
     }
@@ -76,7 +76,7 @@ public class UsuarioDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.error("buscar usuarios");
+            fu.errorSQL(ex, "buscar usuarios");
         }
         return usuarios;
     }
@@ -100,7 +100,7 @@ public class UsuarioDAO {
             ConnBD.CerrarConexionBD();
             return codigoInsertado;
         }catch(Exception ex){
-            fu.error("registrar el usuario");
+            fu.errorSQL(ex, "registrar el usuario");
             return 0;
         }
     }
@@ -120,7 +120,7 @@ public class UsuarioDAO {
             ConnBD.CerrarConexionBD();
             return registrosActualizados;
         }catch(Exception ex){
-            fu.error("actualizar el usuario");
+            fu.errorSQL(ex, "actualizar el usuario");
             return 0;
         }
     }
@@ -136,7 +136,7 @@ public class UsuarioDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.error("eliminar el usuario");
+            fu.errorSQL(ex, "eliminar el usuario");
             return 0;
         }
     }

--- a/src/dao/VarianteProductoDAO.java
+++ b/src/dao/VarianteProductoDAO.java
@@ -22,7 +22,7 @@ public class VarianteProductoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el producto");
             return false;
         }
     }
@@ -45,7 +45,7 @@ public class VarianteProductoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar variantes");
         }
         return lista;
     }
@@ -71,7 +71,7 @@ public class VarianteProductoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar la variante");
             return 0;
         }
     }
@@ -91,11 +91,15 @@ public class VarianteProductoDAO {
             ps.setInt(4, dto.getStock());
             ps.setInt(5, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Variante actualizada. Registros: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Variante no encontrada");
+            }else{
+                fu.MostrarAlertas("Informacion", "Variante actualizada. Registros: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar la variante");
             return 0;
         }
     }
@@ -107,11 +111,15 @@ public class VarianteProductoDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Informacion", "Variante eliminada. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Variante no encontrada");
+            }else{
+                fu.MostrarAlertas("Informacion", "Variante eliminada. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar la variante");
             return 0;
         }
     }

--- a/src/dao/VarianteProductoDAO.java
+++ b/src/dao/VarianteProductoDAO.java
@@ -22,7 +22,7 @@ public class VarianteProductoDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -45,7 +45,7 @@ public class VarianteProductoDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return lista;
     }
@@ -53,7 +53,7 @@ public class VarianteProductoDAO {
     public int InsertarVariante(VarianteProductoDTO dto){
         try{
             if(!existeProducto(dto.getProductoId())){
-                fu.MostrarAlertas("Datos invalidos", "Producto inexistente");
+                fu.datosInvalidos("Producto inexistente");
                 return 0;
             }
             String sql = "INSERT INTO variantes_producto(producto_id, sku, precio, stock) VALUES(?,?,?,?)";
@@ -71,7 +71,7 @@ public class VarianteProductoDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -79,7 +79,7 @@ public class VarianteProductoDAO {
     public int ActualizarVariante(VarianteProductoDTO dto){
         try{
             if(!existeProducto(dto.getProductoId())){
-                fu.MostrarAlertas("Datos invalidos", "Producto inexistente");
+                fu.datosInvalidos("Producto inexistente");
                 return 0;
             }
             String sql = "UPDATE variantes_producto SET producto_id=?, sku=?, precio=?, stock=? WHERE id=?";
@@ -95,7 +95,7 @@ public class VarianteProductoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -111,7 +111,7 @@ public class VarianteProductoDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/dao/VendedorDAO.java
+++ b/src/dao/VendedorDAO.java
@@ -22,7 +22,7 @@ public class VendedorDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "verificar el usuario");
             return false;
         }
     }
@@ -45,7 +45,7 @@ public class VendedorDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "listar vendedores");
         }
         return vendedores;
     }
@@ -69,7 +69,7 @@ public class VendedorDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "buscar vendedores");
         }
         return vendedores;
     }
@@ -97,7 +97,7 @@ public class VendedorDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "registrar el vendedor");
             return 0;
         }
     }
@@ -117,11 +117,15 @@ public class VendedorDAO {
             ps.setBigDecimal(4, dto.getCalificacionPromedio());
             ps.setInt(5, dto.getId());
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Vendedor actualizado. Registros modificados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Vendedor no encontrado");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Vendedor actualizado. Registros modificados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "actualizar el vendedor");
             return 0;
         }
     }
@@ -133,11 +137,15 @@ public class VendedorDAO {
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, id);
             int registros = ps.executeUpdate();
-            fu.MostrarAlertas("Información del sistema", "Vendedor eliminado. Registros afectados: "+registros);
+            if(registros==0){
+                fu.datosInvalidos("Vendedor no encontrado");
+            }else{
+                fu.MostrarAlertas("Información del sistema", "Vendedor eliminado. Registros afectados: "+registros);
+            }
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.errorSQL(ex, "procesar los datos");
+            fu.errorSQL(ex, "eliminar el vendedor");
             return 0;
         }
     }

--- a/src/dao/VendedorDAO.java
+++ b/src/dao/VendedorDAO.java
@@ -22,7 +22,7 @@ public class VendedorDAO {
             ConnBD.CerrarConexionBD();
             return existe;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return false;
         }
     }
@@ -45,7 +45,7 @@ public class VendedorDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return vendedores;
     }
@@ -69,7 +69,7 @@ public class VendedorDAO {
             }
             ConnBD.CerrarConexionBD();
         }catch(Exception ex){
-            fu.MostrarAlertas("Error", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
         }
         return vendedores;
     }
@@ -77,7 +77,7 @@ public class VendedorDAO {
     public int InsertarVendedor(VendedorDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "El usuario especificado no existe");
+                fu.datosInvalidos("El usuario especificado no existe");
                 return 0;
             }
             String sql = "INSERT INTO vendedores(usuario_id, nombre_tienda, descripcion, calificacion_promedio) VALUES(?,?,?,?)";
@@ -97,7 +97,7 @@ public class VendedorDAO {
             ConnBD.CerrarConexionBD();
             return codigo;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -105,7 +105,7 @@ public class VendedorDAO {
     public int ActualizarVendedor(VendedorDTO dto){
         try{
             if(!existeUsuario(dto.getUsuarioId())){
-                fu.MostrarAlertas("Datos inválidos", "El usuario especificado no existe");
+                fu.datosInvalidos("El usuario especificado no existe");
                 return 0;
             }
             String sql = "UPDATE vendedores SET usuario_id=?, nombre_tienda=?, descripcion=?, calificacion_promedio=? WHERE id=?";
@@ -121,7 +121,7 @@ public class VendedorDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }
@@ -137,7 +137,7 @@ public class VendedorDAO {
             ConnBD.CerrarConexionBD();
             return registros;
         }catch(Exception ex){
-            fu.MostrarAlertas("Error del sistema", ex.toString());
+            fu.errorSQL(ex, "procesar los datos");
             return 0;
         }
     }

--- a/src/proyectobd/ParametrosGenerales/BaseFeedback.java
+++ b/src/proyectobd/ParametrosGenerales/BaseFeedback.java
@@ -1,0 +1,55 @@
+package proyectobd.ParametrosGenerales;
+
+import javafx.scene.control.Alert;
+
+public class BaseFeedback {
+    protected void mostrar(Alert.AlertType tipo, String titulo, String mensaje){
+        Alert alerta = new Alert(tipo);
+        alerta.setTitle(titulo);
+        alerta.setHeaderText(null);
+        alerta.setContentText(mensaje);
+        alerta.setWidth(640);
+        alerta.setHeight(250);
+        alerta.showAndWait();
+    }
+
+    // Compatibilidad con llamadas existentes
+    public void MostrarAlertas(String titulo, String mensaje){
+        if(titulo.toLowerCase().startsWith("error")){
+            mostrar(Alert.AlertType.ERROR, "Error", "Ocurrió un problema. Por favor intente nuevamente.");
+        }else{
+            mostrar(Alert.AlertType.INFORMATION, titulo, mensaje);
+        }
+    }
+
+    public void info(String mensaje){
+        mostrar(Alert.AlertType.INFORMATION, "Información", mensaje);
+    }
+
+    public void error(String operacion){
+        mostrar(Alert.AlertType.ERROR, "Error", "No se pudo " + operacion + ". Por favor intente nuevamente.");
+    }
+
+    public void datosInvalidos(String detalle){
+        mostrar(Alert.AlertType.WARNING, "Datos inválidos", detalle);
+    }
+
+    public void errorSQL(Exception ex, String operacion){
+        String msg = "No se pudo " + operacion + ". ";
+        String lower = ex.getMessage().toLowerCase();
+        if(ex instanceof java.sql.SQLIntegrityConstraintViolationException){
+            if(lower.contains("duplicate")){
+                msg += "El registro ya existe.";
+            }else if(lower.contains("foreign key")){
+                msg += "Datos relacionados no válidos.";
+            }else if(lower.contains("check")){
+                msg += "Valores fuera de rango.";
+            }else{
+                msg += "Violación de integridad de datos.";
+            }
+        }else{
+            msg += "Por favor revise los datos.";
+        }
+        mostrar(Alert.AlertType.ERROR, "Error", msg);
+    }
+}

--- a/src/proyectobd/ParametrosGenerales/FeedbackCarrito.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackCarrito.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackCarrito {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackCarrito extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackCarritoItem.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackCarritoItem.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackCarritoItem {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackCarritoItem extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackCategoria.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackCategoria.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackCategoria {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackCategoria extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackCupon.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackCupon.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackCupon {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackCupon extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackDireccion.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackDireccion.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackDireccion {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackDireccion extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackEnvio.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackEnvio.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackEnvio {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackEnvio extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackImagenProducto.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackImagenProducto.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackImagenProducto {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackImagenProducto extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackListaDeseo.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackListaDeseo.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackListaDeseo {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackListaDeseo extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackListaDeseoItem.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackListaDeseoItem.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackListaDeseoItem {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackListaDeseoItem extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackOferta.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackOferta.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackOferta {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackOferta extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackOrden.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackOrden.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackOrden {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackOrden extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackOrdenItem.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackOrdenItem.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackOrdenItem {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackOrdenItem extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackPago.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackPago.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackPago {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackPago extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackProducto.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackProducto.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackProducto {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackProducto extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackResena.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackResena.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackResena {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackResena extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackRol.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackRol.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackRol {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackRol extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackUsuario.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackUsuario.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackUsuario {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackUsuario extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackVarianteProducto.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackVarianteProducto.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackVarianteProducto {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackVarianteProducto extends BaseFeedback {
 }

--- a/src/proyectobd/ParametrosGenerales/FeedbackVendedor.java
+++ b/src/proyectobd/ParametrosGenerales/FeedbackVendedor.java
@@ -1,15 +1,4 @@
 package proyectobd.ParametrosGenerales;
 
-import javafx.scene.control.Alert;
-
-public class FeedbackVendedor {
-    public void MostrarAlertas(String titulo, String mensaje){
-        Alert alerta = new Alert(Alert.AlertType.INFORMATION);
-        alerta.setTitle(titulo);
-        alerta.setHeaderText(null);
-        alerta.setContentText(mensaje);
-        alerta.setWidth(640);
-        alerta.setHeight(250);
-        alerta.showAndWait();
-    }
+public class FeedbackVendedor extends BaseFeedback {
 }


### PR DESCRIPTION
## Summary
- add reusable SQL error helper in `BaseFeedback`
- switch DAO catch blocks to `errorSQL` for clearer messages
- warn users via `datosInvalidos` when input is invalid

## Testing
- `javac @sources.txt` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68517b3b77ac8332988bcd3daafedd24