### PR TITLE
Add profile image support for users

### DIFF
--- a/src/dao/UsuarioDAO.java
+++ b/src/dao/UsuarioDAO.java
@@ -31,7 +31,7 @@ public class UsuarioDAO {
         ObservableList<UsuarioDTO> usuarios=FXCollections.observableArrayList();
         ConectorBD ConnBD=new ConectorBD();
         ResultSet rs=null;
-        String sql="SELECT id, rol_id, nombre, email, contraseña, creado_en FROM usuarios ORDER BY nombre";
+        String sql="SELECT id, rol_id, nombre, email, contraseña, imagen_perfil, creado_en FROM usuarios ORDER BY nombre";
         try{
             Statement st=ConnBD.AbrirConexionBD().createStatement();
             rs=st.executeQuery(sql);
@@ -42,6 +42,7 @@ public class UsuarioDAO {
                 usrdto.setNombre(rs.getString("nombre"));
                 usrdto.setEmail(rs.getString("email"));
                 usrdto.setContrasena(rs.getString("contraseña"));
+                usrdto.setImagenPerfil(rs.getString("imagen_perfil"));
                 usrdto.setCreadoEn(rs.getTimestamp("creado_en"));
                 usuarios.add(usrdto);
             }
@@ -58,7 +59,7 @@ public class UsuarioDAO {
         ObservableList<UsuarioDTO> usuarios=FXCollections.observableArrayList();
         ConectorBD ConnBD=new ConectorBD();
         ResultSet rs=null;
-        String sql="SELECT id, rol_id, nombre, email, contraseña, creado_en FROM usuarios "
+        String sql="SELECT id, rol_id, nombre, email, contraseña, imagen_perfil, creado_en FROM usuarios "
                 + "WHERE nombre LIKE '%"+CriterioBusqueda+"%' OR email LIKE '%"+CriterioBusqueda+"%'"
                 + " ORDER BY nombre";
         try{
@@ -71,6 +72,7 @@ public class UsuarioDAO {
                 usrdto.setNombre(rs.getString("nombre"));
                 usrdto.setEmail(rs.getString("email"));
                 usrdto.setContrasena(rs.getString("contraseña"));
+                usrdto.setImagenPerfil(rs.getString("imagen_perfil"));
                 usrdto.setCreadoEn(rs.getTimestamp("creado_en"));
                 usuarios.add(usrdto);
             }
@@ -83,13 +85,14 @@ public class UsuarioDAO {
 
     public int InsertarUsuario(UsuarioDTO usrdto){
         try{
-            String sql="INSERT INTO usuarios(rol_id, nombre, email, contraseña) VALUES(?,?,?,?)";
+            String sql="INSERT INTO usuarios(rol_id, nombre, email, contraseña, imagen_perfil) VALUES(?,?,?,?,?)";
             ConectorBD ConnBD=new ConectorBD();
             PreparedStatement ps=ConnBD.AbrirConexionBD().prepareStatement(sql,Statement.RETURN_GENERATED_KEYS);
             ps.setInt(1, usrdto.getRolId());
             ps.setString(2, usrdto.getNombre());
             ps.setString(3, usrdto.getEmail());
             ps.setString(4, usrdto.getContrasena());
+            ps.setString(5, usrdto.getImagenPerfil());
             ps.executeUpdate();
             ResultSet rs=ps.getGeneratedKeys();
             int codigoInsertado=0;
@@ -107,14 +110,15 @@ public class UsuarioDAO {
 
     public int ActualizarUsuario(UsuarioDTO usrdto){
         try{
-            String sql="UPDATE usuarios SET rol_id=?, nombre=?, email=?, contraseña=? WHERE id=?";
+            String sql="UPDATE usuarios SET rol_id=?, nombre=?, email=?, contraseña=?, imagen_perfil=? WHERE id=?";
             ConectorBD ConnBD=new ConectorBD();
             PreparedStatement ps=ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, usrdto.getRolId());
             ps.setString(2, usrdto.getNombre());
             ps.setString(3, usrdto.getEmail());
             ps.setString(4, usrdto.getContrasena());
-            ps.setInt(5, usrdto.getId());
+            ps.setString(5, usrdto.getImagenPerfil());
+            ps.setInt(6, usrdto.getId());
             int registrosActualizados=ps.executeUpdate();
             fu.MostrarAlertas("Información", "Usuario actualizado. Registros modificados: "+registrosActualizados);
             ConnBD.CerrarConexionBD();

--- a/src/dao/UsuarioDAO.java
+++ b/src/dao/UsuarioDAO.java
@@ -31,7 +31,8 @@ public class UsuarioDAO {
         ObservableList<UsuarioDTO> usuarios=FXCollections.observableArrayList();
         ConectorBD ConnBD=new ConectorBD();
         ResultSet rs=null;
-        String sql="SELECT id, rol_id, nombre, email, contraseña, imagen_perfil, creado_en FROM usuarios ORDER BY nombre";
+        String sql="SELECT u.id, u.rol_id, r.nombre AS rol_nombre, u.nombre, u.email, u.contraseña, u.imagen_perfil, u.creado_en "
+                + "FROM usuarios u JOIN roles r ON u.rol_id=r.id ORDER BY u.nombre";
         try{
             Statement st=ConnBD.AbrirConexionBD().createStatement();
             rs=st.executeQuery(sql);
@@ -39,6 +40,7 @@ public class UsuarioDAO {
                 UsuarioDTO usrdto=new UsuarioDTO();
                 usrdto.setId(rs.getInt("id"));
                 usrdto.setRolId(rs.getInt("rol_id"));
+                usrdto.setRolNombre(rs.getString("rol_nombre"));
                 usrdto.setNombre(rs.getString("nombre"));
                 usrdto.setEmail(rs.getString("email"));
                 usrdto.setContrasena(rs.getString("contraseña"));
@@ -59,9 +61,10 @@ public class UsuarioDAO {
         ObservableList<UsuarioDTO> usuarios=FXCollections.observableArrayList();
         ConectorBD ConnBD=new ConectorBD();
         ResultSet rs=null;
-        String sql="SELECT id, rol_id, nombre, email, contraseña, imagen_perfil, creado_en FROM usuarios "
-                + "WHERE nombre LIKE '%"+CriterioBusqueda+"%' OR email LIKE '%"+CriterioBusqueda+"%'"
-                + " ORDER BY nombre";
+        String sql="SELECT u.id, u.rol_id, r.nombre AS rol_nombre, u.nombre, u.email, u.contraseña, u.imagen_perfil, u.creado_en "
+                + "FROM usuarios u JOIN roles r ON u.rol_id=r.id "
+                + "WHERE u.nombre LIKE '%"+CriterioBusqueda+"%' OR u.email LIKE '%"+CriterioBusqueda+"%' "
+                + "ORDER BY u.nombre";
         try{
             Statement st=ConnBD.AbrirConexionBD().createStatement();
             rs=st.executeQuery(sql);
@@ -69,6 +72,7 @@ public class UsuarioDAO {
                 UsuarioDTO usrdto=new UsuarioDTO();
                 usrdto.setId(rs.getInt("id"));
                 usrdto.setRolId(rs.getInt("rol_id"));
+                usrdto.setRolNombre(rs.getString("rol_nombre"));
                 usrdto.setNombre(rs.getString("nombre"));
                 usrdto.setEmail(rs.getString("email"));
                 usrdto.setContrasena(rs.getString("contraseña"));

--- a/src/dto/RolDTO.java
+++ b/src/dto/RolDTO.java
@@ -19,4 +19,9 @@ public class RolDTO {
     public void setNombre(String nombre) {
         this.nombre = nombre;
     }
+
+    @Override
+    public String toString() {
+        return nombre;
+    }
 }

--- a/src/dto/UsuarioDTO.java
+++ b/src/dto/UsuarioDTO.java
@@ -18,6 +18,7 @@ public class UsuarioDTO {
     // Tabla usuarios de la nueva base de datos
     private int id;
     private int rolId;
+    private String rolNombre;
     private String nombre;
     private String email;
     private String contrasena;
@@ -38,6 +39,14 @@ public class UsuarioDTO {
 
     public void setRolId(int rolId) {
         this.rolId = rolId;
+    }
+
+    public String getRolNombre() {
+        return rolNombre;
+    }
+
+    public void setRolNombre(String rolNombre) {
+        this.rolNombre = rolNombre;
     }
 
     public String getNombre() {

--- a/src/dto/UsuarioDTO.java
+++ b/src/dto/UsuarioDTO.java
@@ -21,6 +21,7 @@ public class UsuarioDTO {
     private String nombre;
     private String email;
     private String contrasena;
+    private String imagenPerfil;
     private Timestamp creadoEn;
 
     public int getId() {
@@ -61,6 +62,14 @@ public class UsuarioDTO {
 
     public void setContrasena(String contrasena) {
         this.contrasena = contrasena;
+    }
+
+    public String getImagenPerfil() {
+        return imagenPerfil;
+    }
+
+    public void setImagenPerfil(String imagenPerfil) {
+        this.imagenPerfil = imagenPerfil;
     }
 
     public Timestamp getCreadoEn() {

--- a/src/proyectobd/UsuariosGui/Lst_Usuarios_GuiController.java
+++ b/src/proyectobd/UsuariosGui/Lst_Usuarios_GuiController.java
@@ -26,7 +26,7 @@ public class Lst_Usuarios_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<UsuarioDTO> tbl_Lista;
     @FXML private TableColumn<UsuarioDTO, Integer> col_id;
-    @FXML private TableColumn<UsuarioDTO, Integer> col_rol;
+    @FXML private TableColumn<UsuarioDTO, String> col_rol;
     @FXML private TableColumn<UsuarioDTO, String> col_nombre;
     @FXML private TableColumn<UsuarioDTO, String> col_email;
 
@@ -48,7 +48,7 @@ public class Lst_Usuarios_GuiController implements Initializable {
             UsuarioDAO dao = new UsuarioDAO();
             ObservableList<UsuarioDTO> lista = dao.ListarUsuarios();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_rol.setCellValueFactory(new PropertyValueFactory<>("rolId"));
+            col_rol.setCellValueFactory(new PropertyValueFactory<>("rolNombre"));
             col_nombre.setCellValueFactory(new PropertyValueFactory<>("nombre"));
             col_email.setCellValueFactory(new PropertyValueFactory<>("email"));
             tbl_Lista.setItems(lista);

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
@@ -6,6 +6,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.text.Font?>
@@ -25,6 +26,7 @@
             <content>
                 <AnchorPane prefHeight="240.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
                     <children>
+                        <ImageView fx:id="img_perfil" fitHeight="120.0" fitWidth="90.0" layoutX="20.0" layoutY="24.0" pickOnBounds="true" preserveRatio="true" />
                         <Label layoutX="116.0" layoutY="28.0" text="ID:" />
                         <TextField fx:id="txt_id" layoutX="160.0" layoutY="24.0" prefWidth="400.0" />
                         <Label layoutX="94.0" layoutY="64.0" text="Rol ID:" />

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Mnt_Usuarios_GuiController">
+<AnchorPane fx:id="Ap_Main" prefHeight="430.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Mnt_Usuarios_GuiController">
     <children>
         <Pane prefHeight="39.0" prefWidth="600.0" style="-fx-background-color: #1e90ff;">
             <children>
@@ -21,9 +21,9 @@
                 </Label>
             </children>
         </Pane>
-        <TitledPane layoutY="39.0" prefHeight="230.0" prefWidth="600.0" text="Detalles del Registro" animated="false">
+        <TitledPane layoutY="39.0" prefHeight="260.0" prefWidth="600.0" text="Detalles del Registro" animated="false">
             <content>
-                <AnchorPane prefHeight="210.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
+                <AnchorPane prefHeight="240.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
                     <children>
                         <Label layoutX="116.0" layoutY="28.0" text="ID:" />
                         <TextField fx:id="txt_id" layoutX="160.0" layoutY="24.0" prefWidth="400.0" />
@@ -35,11 +35,14 @@
                         <TextField fx:id="txt_email" layoutX="160.0" layoutY="132.0" prefWidth="400.0" />
                         <Label layoutX="62.0" layoutY="172.0" text="Contraseña:" />
                         <PasswordField fx:id="txt_contrasena" layoutX="160.0" layoutY="168.0" prefWidth="400.0" />
+                        <Label layoutX="83.0" layoutY="204.0" text="Imagen:" />
+                        <TextField fx:id="txt_imagen" layoutX="160.0" layoutY="200.0" prefWidth="340.0" />
+                        <Button fx:id="btn_BuscarImagen" layoutX="505.0" layoutY="200.0" mnemonicParsing="false" onAction="#call_SeleccionarImagen" text="..." />
                     </children>
                 </AnchorPane>
             </content>
         </TitledPane>
-        <TitledPane layoutY="269.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
+        <TitledPane layoutY="299.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
             <content>
                 <AnchorPane prefHeight="27.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
                     <children>

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
@@ -29,7 +29,7 @@
                         <ImageView fx:id="img_perfil" fitHeight="150.0" fitWidth="150.0" layoutX="20.0" layoutY="24.0" pickOnBounds="true" preserveRatio="true" style="-fx-border-color: black; -fx-border-width: 1; -fx-background-color: lightgray;" />
                         <Label layoutX="190.0" layoutY="28.0" text="ID:" />
                         <TextField fx:id="txt_id" layoutX="230.0" layoutY="24.0" prefWidth="360.0" />
-                        <Label layoutX="168.0" layoutY="64.0" text="Rol ID:" />
+                        <Label layoutX="168.0" layoutY="64.0" text="Rol:" />
                         <ComboBox fx:id="cmb_rol" layoutX="230.0" layoutY="60.0" prefWidth="360.0" />
                         <Label layoutX="160.0" layoutY="100.0" text="Nombre:" />
                         <TextField fx:id="txt_nombre" layoutX="230.0" layoutY="96.0" prefWidth="360.0" />

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="430.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Mnt_Usuarios_GuiController">
+<AnchorPane fx:id="Ap_Main" prefHeight="480.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Mnt_Usuarios_GuiController">
     <children>
         <Pane prefHeight="39.0" prefWidth="600.0" style="-fx-background-color: #1e90ff;">
             <children>
@@ -22,29 +22,29 @@
                 </Label>
             </children>
         </Pane>
-        <TitledPane layoutY="39.0" prefHeight="260.0" prefWidth="600.0" text="Detalles del Registro" animated="false">
+        <TitledPane layoutY="39.0" prefHeight="300.0" prefWidth="600.0" text="Detalles del Registro" animated="false">
             <content>
-                <AnchorPane prefHeight="240.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
+                <AnchorPane prefHeight="280.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
                     <children>
-                        <ImageView fx:id="img_perfil" fitHeight="120.0" fitWidth="90.0" layoutX="20.0" layoutY="24.0" pickOnBounds="true" preserveRatio="true" />
-                        <Label layoutX="116.0" layoutY="28.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="160.0" layoutY="24.0" prefWidth="400.0" />
-                        <Label layoutX="94.0" layoutY="64.0" text="Rol ID:" />
-                        <ComboBox fx:id="cmb_rol" layoutX="160.0" layoutY="60.0" prefWidth="400.0" />
-                        <Label layoutX="86.0" layoutY="100.0" text="Nombre:" />
-                        <TextField fx:id="txt_nombre" layoutX="160.0" layoutY="96.0" prefWidth="400.0" />
-                        <Label layoutX="101.0" layoutY="136.0" text="Email:" />
-                        <TextField fx:id="txt_email" layoutX="160.0" layoutY="132.0" prefWidth="400.0" />
-                        <Label layoutX="62.0" layoutY="172.0" text="Contraseña:" />
-                        <PasswordField fx:id="txt_contrasena" layoutX="160.0" layoutY="168.0" prefWidth="400.0" />
-                        <Label layoutX="83.0" layoutY="204.0" text="Imagen:" />
-                        <TextField fx:id="txt_imagen" layoutX="160.0" layoutY="200.0" prefWidth="340.0" />
-                        <Button fx:id="btn_BuscarImagen" layoutX="505.0" layoutY="200.0" mnemonicParsing="false" onAction="#call_SeleccionarImagen" text="..." />
+                        <ImageView fx:id="img_perfil" fitHeight="150.0" fitWidth="150.0" layoutX="20.0" layoutY="24.0" pickOnBounds="true" preserveRatio="true" style="-fx-border-color: black; -fx-border-width: 1; -fx-background-color: lightgray;" />
+                        <Label layoutX="190.0" layoutY="28.0" text="ID:" />
+                        <TextField fx:id="txt_id" layoutX="230.0" layoutY="24.0" prefWidth="360.0" />
+                        <Label layoutX="168.0" layoutY="64.0" text="Rol ID:" />
+                        <ComboBox fx:id="cmb_rol" layoutX="230.0" layoutY="60.0" prefWidth="360.0" />
+                        <Label layoutX="160.0" layoutY="100.0" text="Nombre:" />
+                        <TextField fx:id="txt_nombre" layoutX="230.0" layoutY="96.0" prefWidth="360.0" />
+                        <Label layoutX="175.0" layoutY="136.0" text="Email:" />
+                        <TextField fx:id="txt_email" layoutX="230.0" layoutY="132.0" prefWidth="360.0" />
+                        <Label layoutX="136.0" layoutY="172.0" text="Contraseña:" />
+                        <PasswordField fx:id="txt_contrasena" layoutX="230.0" layoutY="168.0" prefWidth="360.0" />
+                        <Label layoutX="157.0" layoutY="204.0" text="Imagen:" />
+                        <TextField fx:id="txt_imagen" layoutX="230.0" layoutY="200.0" prefWidth="330.0" />
+                        <Button fx:id="btn_BuscarImagen" layoutX="560.0" layoutY="200.0" mnemonicParsing="false" onAction="#call_SeleccionarImagen" text="..." />
                     </children>
                 </AnchorPane>
             </content>
         </TitledPane>
-        <TitledPane layoutY="299.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
+        <TitledPane layoutY="339.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
             <content>
                 <AnchorPane prefHeight="27.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
                     <children>

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
@@ -50,6 +50,10 @@ public class Mnt_Usuarios_GuiController implements Initializable {
 
     public void call_Grabar(){
         UsuarioDAO dao = new UsuarioDAO();
+        if(!emailValido(txt_email.getText())){
+            fu.datosInvalidos("Ingrese un correo electr\u00f3nico v\u00e1lido.");
+            return;
+        }
         if(!actualizar){
             try{
                 UsuarioDTO dto = new UsuarioDTO();
@@ -134,5 +138,10 @@ public class Mnt_Usuarios_GuiController implements Initializable {
             txt_imagen.setText(f.getAbsolutePath());
             img_perfil.setImage(new Image(f.toURI().toString()));
         }
+    }
+
+    private boolean emailValido(String email){
+        if(email == null) return false;
+        return email.matches("^[\\w.+\\-]+@([\\w-]+\\.)+[\\w-]{2,}$");
     }
 }

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
@@ -15,6 +15,8 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.ComboBox;
 import javafx.stage.FileChooser;
 import java.io.File;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.layout.AnchorPane;
@@ -29,6 +31,7 @@ public class Mnt_Usuarios_GuiController implements Initializable {
     @FXML private Button btn_Cerrar;
     @FXML private Button btn_Grabar;
     @FXML private Button btn_BuscarImagen;
+    @FXML private ImageView img_perfil;
     @FXML private TextField txt_id;
     @FXML private ComboBox<RolDTO> cmb_rol;
     @FXML private TextField txt_imagen;
@@ -103,6 +106,12 @@ public class Mnt_Usuarios_GuiController implements Initializable {
             txt_email.setText(dto.getEmail());
             txt_contrasena.setText(dto.getContrasena());
             txt_imagen.setText(dto.getImagenPerfil());
+            if(dto.getImagenPerfil() != null){
+                File f = new File(dto.getImagenPerfil());
+                if(f.exists()){
+                    img_perfil.setImage(new Image(f.toURI().toString()));
+                }
+            }
         }
     }
 
@@ -123,6 +132,7 @@ public class Mnt_Usuarios_GuiController implements Initializable {
         File f = fc.showOpenDialog(Ap_Main.getScene().getWindow());
         if(f != null){
             txt_imagen.setText(f.getAbsolutePath());
+            img_perfil.setImage(new Image(f.toURI().toString()));
         }
     }
 }

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
@@ -13,6 +13,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
 import javafx.scene.control.ComboBox;
+import javafx.stage.FileChooser;
+import java.io.File;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.layout.AnchorPane;
@@ -26,8 +28,10 @@ public class Mnt_Usuarios_GuiController implements Initializable {
     @FXML private AnchorPane Ap_Main;
     @FXML private Button btn_Cerrar;
     @FXML private Button btn_Grabar;
+    @FXML private Button btn_BuscarImagen;
     @FXML private TextField txt_id;
-    @FXML private ComboBox<Integer> cmb_rol;
+    @FXML private ComboBox<RolDTO> cmb_rol;
+    @FXML private TextField txt_imagen;
     @FXML private TextField txt_nombre;
     @FXML private TextField txt_email;
     @FXML private PasswordField txt_contrasena;
@@ -46,10 +50,11 @@ public class Mnt_Usuarios_GuiController implements Initializable {
         if(!actualizar){
             try{
                 UsuarioDTO dto = new UsuarioDTO();
-                dto.setRolId(cmb_rol.getValue());
+                dto.setRolId(cmb_rol.getValue().getId());
                 dto.setNombre(txt_nombre.getText());
                 dto.setEmail(txt_email.getText());
                 dto.setContrasena(txt_contrasena.getText());
+                dto.setImagenPerfil(txt_imagen.getText());
                 int id = dao.InsertarUsuario(dto);
                 if(id>0){
                     txt_id.setText(Integer.toString(id));
@@ -61,10 +66,11 @@ public class Mnt_Usuarios_GuiController implements Initializable {
         }else{
             Stage stage = (Stage) Ap_Main.getScene().getWindow();
             UsuarioDTO dto = (UsuarioDTO) stage.getUserData();
-            dto.setRolId(cmb_rol.getValue());
+            dto.setRolId(cmb_rol.getValue().getId());
             dto.setNombre(txt_nombre.getText());
             dto.setEmail(txt_email.getText());
             dto.setContrasena(txt_contrasena.getText());
+            dto.setImagenPerfil(txt_imagen.getText());
             try{
                 int reg = dao.ActualizarUsuario(dto);
                 if(reg>0){
@@ -87,23 +93,36 @@ public class Mnt_Usuarios_GuiController implements Initializable {
         if(dto != null){
             actualizar = true;
             txt_id.setText(Integer.toString(dto.getId()));
-            cmb_rol.setValue(dto.getRolId());
+            for (RolDTO r : cmb_rol.getItems()) {
+                if(r.getId() == dto.getRolId()) {
+                    cmb_rol.setValue(r);
+                    break;
+                }
+            }
             txt_nombre.setText(dto.getNombre());
             txt_email.setText(dto.getEmail());
             txt_contrasena.setText(dto.getContrasena());
+            txt_imagen.setText(dto.getImagenPerfil());
         }
     }
 
     private void cargarCombos(){
         try {
-            ObservableList<Integer> roles = FXCollections.observableArrayList();
+            ObservableList<RolDTO> roles = FXCollections.observableArrayList();
             RolDAO rdao = new RolDAO();
-            for (RolDTO r : rdao.ListarRoles()) {
-                roles.add(r.getId());
-            }
+            roles.addAll(rdao.ListarRoles());
             cmb_rol.setItems(roles);
         } catch (Exception ex) {
             fu.MostrarAlertas("Error", ex.toString());
+        }
+    }
+
+    public void call_SeleccionarImagen(){
+        FileChooser fc = new FileChooser();
+        fc.getExtensionFilters().add(new FileChooser.ExtensionFilter("Im\u00e1genes", "*.png", "*.jpg", "*.jpeg", "*.gif"));
+        File f = fc.showOpenDialog(Ap_Main.getScene().getWindow());
+        if(f != null){
+            txt_imagen.setText(f.getAbsolutePath());
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend `UsuarioDTO` with `imagenPerfil`
- show role names in the user maintenance combo box
- allow selecting a profile image when creating/editing a user
- persist `imagen_perfil` in `UsuarioDAO`

## Testing
- `ant -q jar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e30faef4833291759279e156bd20