### PR TITLE
Standardize remaining list screens

### DIFF
--- a/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_Gui.fxml
+++ b/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_Gui.fxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
@@ -10,51 +10,50 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="300.0" layoutY="3.0" text="Items de Carrito" styleClass="header-title">
-               <font><Font size="24.0" /></font>
-            </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Carrito ID:" />
-                  <TextField fx:id="txt_Buscar" layoutX="110.0" layoutY="18.0" prefHeight="25.0" prefWidth="590.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
-                      <TableColumn fx:id="col_carrito" prefWidth="75.0" text="Carrito" />
-                      <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante" />
-                      <TableColumn fx:id="col_cantidad" prefWidth="75.0" text="Cantidad" />
-                    </columns>
-                    <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+      <BorderPane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0">
+         <top>
+            <VBox>
+               <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+                  <padding><Insets left="10.0" right="10.0"/></padding>
+                  <Label text="Items de Carrito" styleClass="header-title">
+                     <font><Font size="24.0"/></font>
+                  </Label>
+               </HBox>
+               <HBox alignment="CENTER_LEFT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Label text="Carrito ID:"/>
+                  <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS"/>
+               </HBox>
+               <Separator/>
+            </VBox>
+         </top>
+         <center>
+            <VBox spacing="5.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+                  <columns>
+                     <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>
+                     <TableColumn fx:id="col_carrito" prefWidth="75.0" text="Carrito"/>
+                     <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante"/>
+                     <TableColumn fx:id="col_cantidad" prefWidth="75.0" text="Cantidad"/>
+                  </columns>
+                  <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>
+               </TableView>
+            </VBox>
+         </center>
+         <bottom>
+            <VBox>
+               <Separator/>
+               <HBox alignment="CENTER_RIGHT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Region HBox.hgrow="ALWAYS"/>
+                  <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+                  <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+                  <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+               </HBox>
+            </VBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_Gui.fxml
+++ b/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_Gui.fxml
@@ -1,47 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CarritoItemsGui.Mnt_CarritoItems_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CarritoItemsGui.Mnt_CarritoItems_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
     <children>
-        <Pane prefHeight="39.0" prefWidth="600.0" styleClass="header-section">
-            <children>
-                <Label layoutX="160.0" layoutY="2.0" text="Mantenimiento Items" styleClass="header-title">
-                    <font><Font size="24.0"/></font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
-            <content>
-                <AnchorPane prefHeight="230.0" prefWidth="598.0">
+        <BorderPane fx:id="Ap_Main" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0">
+            <top>
+                <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+                    <padding><Insets left="10.0" right="10.0"/></padding>
+                    <Label text="Mantenimiento Items" styleClass="header-title">
+                        <font><Font size="18.0"/></font>
+                    </Label>
+                </HBox>
+            </top>
+            <center>
+                <GridPane hgap="10.0" vgap="10.0">
+                    <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                    <columnConstraints>
+                        <ColumnConstraints minWidth="70.0"/>
+                        <ColumnConstraints hgrow="ALWAYS"/>
+                    </columnConstraints>
                     <children>
-                        <Label layoutX="96.0" layoutY="36.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="160.0" layoutY="32.0" prefWidth="400.0" />
-                        <Label layoutX="56.0" layoutY="72.0" text="Carrito:" />
-                        <ComboBox fx:id="cmb_carrito" layoutX="160.0" layoutY="68.0" prefWidth="400.0" />
-                        <Label layoutX="48.0" layoutY="108.0" text="Variante:" />
-                        <ComboBox fx:id="cmb_variante" layoutX="160.0" layoutY="104.0" prefWidth="400.0" />
-                        <Label layoutX="92.0" layoutY="144.0" text="Cantidad:" />
-                        <TextField fx:id="txt_cantidad" layoutX="160.0" layoutY="140.0" prefWidth="400.0" />
+                        <Label text="ID:"/>
+                        <TextField fx:id="txt_id" GridPane.columnIndex="1"/>
+                        <Label text="Carrito:" GridPane.rowIndex="1"/>
+                        <ComboBox fx:id="cmb_carrito" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+                        <Label text="Variante:" GridPane.rowIndex="2"/>
+                        <ComboBox fx:id="cmb_variante" GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+                        <Label text="Cantidad:" GridPane.rowIndex="3"/>
+                        <TextField fx:id="txt_cantidad" GridPane.columnIndex="1" GridPane.rowIndex="3"/>
                     </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="289.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane>
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
+                </GridPane>
+            </center>
+            <bottom>
+                <HBox alignment="CENTER_RIGHT" spacing="10.0">
+                    <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                    <Region HBox.hgrow="ALWAYS"/>
+                    <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar"/>
+                    <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+                </HBox>
+            </bottom>
+        </BorderPane>
     </children>
 </AnchorPane>

--- a/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_GuiController.java
+++ b/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_GuiController.java
@@ -16,7 +16,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.ComboBox;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackCarritoItem;
 
@@ -25,7 +25,7 @@ public class Mnt_CarritoItems_GuiController implements Initializable {
     FeedbackCarritoItem fu = new FeedbackCarritoItem();
     private boolean actualizar = false;
 
-    @FXML private AnchorPane Ap_Main;
+    @FXML private BorderPane Ap_Main;
     @FXML private Button btn_Grabar;
     @FXML private Button btn_Cerrar;
     @FXML private TextField txt_id;

--- a/src/proyectobd/CarritosGui/Lst_Carritos_Gui.fxml
+++ b/src/proyectobd/CarritosGui/Lst_Carritos_Gui.fxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
@@ -10,54 +10,49 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="314.0" layoutY="3.0" text="Lista de Carritos" styleClass="header-title">
-               <font>
-                  <Font size="24.0" />
-               </font>
-            </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0">
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Buscar:" />
-                  <TextField fx:id="txt_Buscar" layoutX="75.0" layoutY="18.0" prefHeight="25.0" prefWidth="624.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0">
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-                      <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
-                      <TableColumn fx:id="col_creado" prefWidth="150.0" text="Creado" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane prefHeight="27.0" prefWidth="479.0">
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="405.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="464.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="523.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="582.0" layoutY="8.0" text="Cerrar" mnemonicParsing="false" onAction="#call_CerrarVentana" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+      <BorderPane AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <VBox>
+               <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+                  <padding><Insets left="10.0" right="10.0"/></padding>
+                  <Label text="Lista de Carritos" styleClass="header-title">
+                     <font><Font size="24.0"/></font>
+                  </Label>
+               </HBox>
+               <HBox alignment="CENTER_LEFT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Label text="Buscar:"/>
+                  <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS"/>
+               </HBox>
+               <Separator/>
+            </VBox>
+         </top>
+         <center>
+            <VBox spacing="5.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+                  <columns>
+                     <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
+                     <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario"/>
+                     <TableColumn fx:id="col_creado" prefWidth="150.0" text="Creado"/>
+                  </columns>
+                  <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>
+               </TableView>
+            </VBox>
+         </center>
+         <bottom>
+            <VBox>
+               <Separator/>
+               <HBox alignment="CENTER_RIGHT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Region HBox.hgrow="ALWAYS"/>
+                  <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+                  <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+                  <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+               </HBox>
+            </VBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/CarritosGui/Mnt_Carritos_Gui.fxml
+++ b/src/proyectobd/CarritosGui/Mnt_Carritos_Gui.fxml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
-<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
@@ -11,21 +10,39 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane prefHeight="39.0" prefWidth="400.0" styleClass="header-section">
-         <children>
-            <Label layoutX="124.0" layoutY="7.0" text="Carrito" styleClass="header-title">
-               <font>
-                  <Font size="18.0" />
-               </font>
-            </Label>
-         </children>
-      </Pane>
-      <Label layoutX="32.0" layoutY="67.0" text="Usuario:" />
-      <ComboBox fx:id="cmb_usuario" layoutX="98.0" layoutY="63.0" prefWidth="250.0" />
-      <Label layoutX="32.0" layoutY="108.0" text="Creado:" />
-      <DatePicker fx:id="dp_creado" layoutX="98.0" layoutY="104.0" prefWidth="250.0" />
-      <Button fx:id="btn_Guardar" layoutX="94.0" layoutY="164.0" mnemonicParsing="false" onAction="#call_Guardar" text="Guardar" />
-      <Button fx:id="btn_Borrar" layoutX="163.0" layoutY="164.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-      <Button fx:id="btn_Cerrar" layoutX="232.0" layoutY="164.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Carrito" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="70.0"/>
+                  <ColumnConstraints hgrow="ALWAYS"/>
+               </columnConstraints>
+               <children>
+                  <Label text="Usuario:"/>
+                  <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1"/>
+                  <Label text="Creado:" GridPane.rowIndex="1"/>
+                  <DatePicker fx:id="dp_creado" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS"/>
+               <Button fx:id="btn_Guardar" onAction="#call_Guardar" text="Guardar"/>
+               <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+            </HBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/CarritosGui/Mnt_Carritos_GuiController.java
+++ b/src/proyectobd/CarritosGui/Mnt_Carritos_GuiController.java
@@ -16,7 +16,7 @@ import javafx.scene.control.ComboBox;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.DatePicker;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackCarrito;
 
@@ -25,7 +25,7 @@ public class Mnt_Carritos_GuiController implements Initializable {
     FeedbackCarrito fu = new FeedbackCarrito();
     private boolean actualizar = false;
 
-    @FXML private AnchorPane Ap_Main;
+    @FXML private BorderPane Ap_Main;
     @FXML private Button btn_Guardar;
     @FXML private Button btn_Borrar;
     @FXML private Button btn_Cerrar;

--- a/src/proyectobd/CategoriasGui/Lst_Categorias_Gui.fxml
+++ b/src/proyectobd/CategoriasGui/Lst_Categorias_Gui.fxml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TableColumn?>
-<?import javafx.scene.control.TableView?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CategoriasGui.Lst_Categorias_GuiController">
@@ -16,54 +10,49 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="302.0" layoutY="3.0" text="Lista de Categorías" styleClass="header-title">
-               <font>
-                  <Font size="24.0" />
-               </font>
-            </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Buscar:" />
-                  <TextField fx:id="txt_Buscar" layoutX="75.0" layoutY="18.0" prefHeight="25.0" prefWidth="624.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-                      <TableColumn fx:id="col_nombre" prefWidth="200.0" text="Nombre" />
-                      <TableColumn fx:id="col_parent" prefWidth="150.0" text="Padre" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" text="Cerrar" mnemonicParsing="false" onAction="#call_CerrarVentana" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+      <BorderPane AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <VBox>
+               <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+                  <padding><Insets left="10.0" right="10.0"/></padding>
+                    <Label text="Lista de Categorías" styleClass="header-title">
+                       <font><Font size="24.0"/></font>
+                    </Label>
+               </HBox>
+               <HBox alignment="CENTER_LEFT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Label text="Buscar:"/>
+                  <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS"/>
+               </HBox>
+               <Separator/>
+            </VBox>
+         </top>
+         <center>
+            <VBox spacing="5.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+                  <columns>
+                     <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
+                     <TableColumn fx:id="col_nombre" prefWidth="200.0" text="Nombre"/>
+                     <TableColumn fx:id="col_parent" prefWidth="150.0" text="Padre"/>
+                  </columns>
+                  <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>
+               </TableView>
+            </VBox>
+         </center>
+         <bottom>
+            <VBox>
+               <Separator/>
+               <HBox alignment="CENTER_RIGHT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Region HBox.hgrow="ALWAYS"/>
+                  <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+                  <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+                  <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+               </HBox>
+            </VBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/CategoriasGui/Mnt_Categorias_Gui.fxml
+++ b/src/proyectobd/CategoriasGui/Mnt_Categorias_Gui.fxml
@@ -15,30 +15,40 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane prefHeight="39.0" prefWidth="400.0" styleClass="header-section">
-         <children>
-            <Label layoutX="80.0" layoutY="3.0" text="Mantenimiento Categorías" styleClass="header-title">
-               <font>
-                  <Font size="20.0" />
-               </font>
-            </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" prefHeight="211.0" prefWidth="400.0" text="Datos" animated="false">
-        <content>
-          <AnchorPane>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento Categorías" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="80.0"/>
+                  <ColumnConstraints hgrow="ALWAYS"/>
+               </columnConstraints>
                <children>
-                  <Label layoutX="25.0" layoutY="22.0" text="ID:" />
-                  <TextField fx:id="txt_id" layoutX="66.0" layoutY="18.0" prefWidth="300.0" />
-                  <Label layoutX="25.0" layoutY="63.0" text="Nombre:" />
-                  <TextField fx:id="txt_nombre" layoutX="83.0" layoutY="59.0" prefWidth="283.0" />
-                  <Label layoutX="25.0" layoutY="104.0" text="Padre:" />
-                  <ComboBox fx:id="cmb_parent" layoutX="83.0" layoutY="100.0" prefWidth="283.0" />
-                  <Button fx:id="btn_Grabar" layoutX="229.0" layoutY="144.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                  <Button fx:id="btn_Cerrar" layoutX="297.0" layoutY="144.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
+                  <Label text="ID:"/>
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1"/>
+                  <Label text="Nombre:" GridPane.rowIndex="1"/>
+                  <TextField fx:id="txt_nombre" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+                  <Label text="Padre:" GridPane.rowIndex="2"/>
+                  <ComboBox fx:id="cmb_parent" GridPane.columnIndex="1" GridPane.rowIndex="2"/>
                </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS"/>
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar"/>
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+            </HBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/CuponesGui/Lst_Cupones_Gui.fxml
+++ b/src/proyectobd/CuponesGui/Lst_Cupones_Gui.fxml
@@ -9,9 +9,16 @@
       <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
    <top>
       <VBox>
-         <HBox alignment="CENTER" prefHeight="60.0">
-            <Label text="Panel de Gestión de Cupones">
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding><Insets left="10.0" right="10.0"/></padding>
+            <Label text="Lista de Cupones" styleClass="header-title">
+               <font><Font size="24.0"/></font>
             </Label>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+            <Label text="ID o Código:"/>
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
          </HBox>
          <Separator/>
       </VBox>
@@ -23,26 +30,7 @@
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox>
-            <Label text="Filtros de Búsqueda">
-            </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0">
-               <padding>
-                  <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
-               </padding>
-               <Label text="ID o Código:">
-               </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
-               <Button text="Buscar" onAction="#call_Buscar"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
-            </HBox>
-         </VBox>
-
          <VBox VBox.vgrow="ALWAYS">
-            <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="Lista de Cupones">
-               </Label>
-            </HBox>
             <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>

--- a/src/proyectobd/CuponesGui/Lst_Cupones_Gui.fxml
+++ b/src/proyectobd/CuponesGui/Lst_Cupones_Gui.fxml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CuponesGui.Lst_Cupones_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CuponesGui.Lst_Cupones_GuiController">
+   <stylesheets>
+      <URL value="@/proyectobd/styles/app.css" />
+   </stylesheets>
    <children>
       <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
    <top>
@@ -17,7 +21,7 @@
          </HBox>
          <HBox alignment="CENTER_LEFT" spacing="10.0">
             <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
-            <Label text="ID o Código:"/>
+            <Label text="Buscar:"/>
             <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
          </HBox>
          <Separator/>
@@ -25,13 +29,11 @@
    </top>
 
    <center>
-      <VBox spacing="10.0">
+      <VBox spacing="5.0">
          <padding>
-            <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
          </padding>
-
-         <VBox VBox.vgrow="ALWAYS">
-            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
                   <TableColumn fx:id="col_codigo" prefWidth="150.0" text="Código"/>
@@ -42,7 +44,6 @@
                   <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
                </columnResizePolicy>
             </TableView>
-         </VBox>
       </VBox>
    </center>
 
@@ -51,7 +52,7 @@
          <Separator/>
          <HBox alignment="CENTER_RIGHT" spacing="10.0">
             <padding>
-               <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
             </padding>
             <Region HBox.hgrow="ALWAYS"/>
             <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>

--- a/src/proyectobd/CuponesGui/Lst_Cupones_GuiController.java
+++ b/src/proyectobd/CuponesGui/Lst_Cupones_GuiController.java
@@ -125,8 +125,4 @@ public class Lst_Cupones_GuiController implements Initializable {
         }
     }
 
-    public void call_Limpiar(){
-        txt_Buscar.clear();
-        call_Buscar();
-    }
 }

--- a/src/proyectobd/CuponesGui/Mnt_Cupones_Gui.fxml
+++ b/src/proyectobd/CuponesGui/Mnt_Cupones_Gui.fxml
@@ -1,44 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
-<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CuponesGui.Mnt_Cupones_GuiController">
-    <children>
-        <Pane prefHeight="50.0" prefWidth="800.0">
-            <children>
-                <Label layoutX="232.0" layoutY="12.0" text="Formulario de Mantenimiento de Cupones" />
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="300.0" prefWidth="800.0" text="Detalles del Registro" animated="false">
-            <content>
-                <AnchorPane prefHeight="280.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Label layoutX="170.0" layoutY="40.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="220.0" layoutY="36.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="158.0" layoutY="76.0" text="Código:" />
-                        <TextField fx:id="txt_codigo" layoutX="220.0" layoutY="72.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="134.0" layoutY="112.0" text="Descuento %:" />
-                        <TextField fx:id="txt_descuento" layoutX="220.0" layoutY="108.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="112.0" layoutY="148.0" text="Fecha Expiración:" />
-                        <DatePicker fx:id="dp_expira" layoutX="220.0" layoutY="144.0" prefWidth="400.0" />
-                        <Label layoutX="142.0" layoutY="184.0" text="Uso Máximo:" />
-                        <TextField fx:id="txt_uso" layoutX="220.0" layoutY="180.0" prefHeight="25.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="339.0" prefHeight="61.0" prefWidth="800.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CuponesGui.Mnt_Cupones_GuiController">
+   <stylesheets>
+      <URL value="@/proyectobd/styles/app.css" />
+   </stylesheets>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento de Cupones" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="120.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Código:" GridPane.rowIndex="1" />
+                  <TextField fx:id="txt_codigo" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Descuento %:" GridPane.rowIndex="2" />
+                  <TextField fx:id="txt_descuento" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Fecha Expiración:" GridPane.rowIndex="3" />
+                  <DatePicker fx:id="dp_expira" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Uso Máximo:" GridPane.rowIndex="4" />
+                  <TextField fx:id="txt_uso" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/DireccionesGui/Lst_Direcciones_Gui.fxml
+++ b/src/proyectobd/DireccionesGui/Lst_Direcciones_Gui.fxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
@@ -10,55 +10,50 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="300.0" layoutY="3.0" text="Lista de Direcciones" styleClass="header-title">
-               <font>
-                  <Font size="24.0" />
-               </font>
-            </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0">
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Buscar:" />
-                  <TextField fx:id="txt_Buscar" layoutX="75.0" layoutY="18.0" prefHeight="25.0" prefWidth="624.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0">
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
-                      <TableColumn fx:id="col_usuario" prefWidth="50.0" text="Usr" />
-                      <TableColumn fx:id="col_ciudad" prefWidth="100.0" text="Ciudad" />
-                      <TableColumn fx:id="col_provincia" prefWidth="100.0" text="Provincia" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane prefHeight="27.0" prefWidth="479.0">
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" text="Cerrar" mnemonicParsing="false" onAction="#call_CerrarVentana" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+      <BorderPane AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <VBox>
+               <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+                  <padding><Insets left="10.0" right="10.0"/></padding>
+                  <Label text="Lista de Direcciones" styleClass="header-title">
+                     <font><Font size="24.0"/></font>
+                  </Label>
+               </HBox>
+               <HBox alignment="CENTER_LEFT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Label text="Buscar:"/>
+                  <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS"/>
+               </HBox>
+               <Separator/>
+            </VBox>
+         </top>
+         <center>
+            <VBox spacing="5.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+                  <columns>
+                     <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>
+                     <TableColumn fx:id="col_usuario" prefWidth="50.0" text="Usr"/>
+                     <TableColumn fx:id="col_ciudad" prefWidth="100.0" text="Ciudad"/>
+                     <TableColumn fx:id="col_provincia" prefWidth="100.0" text="Provincia"/>
+                  </columns>
+                  <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>
+               </TableView>
+            </VBox>
+         </center>
+         <bottom>
+            <VBox>
+               <Separator/>
+               <HBox alignment="CENTER_RIGHT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Region HBox.hgrow="ALWAYS"/>
+                  <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+                  <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+                  <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+               </HBox>
+            </VBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/DireccionesGui/Mnt_Direcciones_Gui.fxml
+++ b/src/proyectobd/DireccionesGui/Mnt_Direcciones_Gui.fxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
@@ -10,46 +10,47 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane prefHeight="39.0" prefWidth="500.0" styleClass="header-section">
-         <children>
-            <Label layoutX="180.0" layoutY="7.0" text="Dirección" styleClass="header-title">
-               <font>
-                  <Font size="18.0" />
-               </font>
-            </Label>
-         </children>
-      </Pane>
-      <GridPane layoutX="25.0" layoutY="55.0" hgap="10" vgap="10">
-        <columnConstraints>
-            <ColumnConstraints minWidth="80" />
-            <ColumnConstraints minWidth="300" />
-        </columnConstraints>
-        <rowConstraints>
-            <RowConstraints minHeight="30" />
-            <RowConstraints minHeight="30" />
-            <RowConstraints minHeight="30" />
-            <RowConstraints minHeight="30" />
-            <RowConstraints minHeight="30" />
-            <RowConstraints minHeight="30" />
-            <RowConstraints minHeight="30" />
-        </rowConstraints>
-        <children>
-          <Label text="Usuario:" GridPane.rowIndex="0" />
-          <ComboBox fx:id="cmb_usuario" GridPane.rowIndex="0" GridPane.columnIndex="1" />
-          <Label text="Alias:" GridPane.rowIndex="1" />
-          <TextField fx:id="txt_alias" GridPane.rowIndex="1" GridPane.columnIndex="1" />
-          <Label text="Dirección:" GridPane.rowIndex="2" />
-          <TextField fx:id="txt_direccion" GridPane.rowIndex="2" GridPane.columnIndex="1" />
-          <Label text="Ciudad:" GridPane.rowIndex="3" />
-          <TextField fx:id="txt_ciudad" GridPane.rowIndex="3" GridPane.columnIndex="1" />
-          <Label text="Provincia:" GridPane.rowIndex="4" />
-          <TextField fx:id="txt_provincia" GridPane.rowIndex="4" GridPane.columnIndex="1" />
-          <Label text="Código Postal:" GridPane.rowIndex="5" />
-          <TextField fx:id="txt_postal" GridPane.rowIndex="5" GridPane.columnIndex="1" />
-          <Label text="Teléfono:" GridPane.rowIndex="6" />
-          <TextField fx:id="txt_telefono" GridPane.rowIndex="6" GridPane.columnIndex="1" />
-        </children>
-      </GridPane>
-      <Button fx:id="btn_Guardar" layoutX="215.0" layoutY="305.0" mnemonicParsing="false" onAction="#call_Guardar" text="Guardar" />
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Dirección" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10" vgap="10">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="80" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="Usuario:" />
+                  <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1" />
+                  <Label text="Alias:" GridPane.rowIndex="1" />
+                  <TextField fx:id="txt_alias" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Dirección:" GridPane.rowIndex="2" />
+                  <TextField fx:id="txt_direccion" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Ciudad:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_ciudad" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Provincia:" GridPane.rowIndex="4" />
+                  <TextField fx:id="txt_provincia" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                  <Label text="Código Postal:" GridPane.rowIndex="5" />
+                  <TextField fx:id="txt_postal" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                  <Label text="Teléfono:" GridPane.rowIndex="6" />
+                  <TextField fx:id="txt_telefono" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Guardar" onAction="#call_Guardar" text="Guardar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/EnviosGui/Lst_Envios_Gui.fxml
+++ b/src/proyectobd/EnviosGui/Lst_Envios_Gui.fxml
@@ -13,15 +13,16 @@
       <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
    <top>
       <VBox>
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-section">
-            <padding>
-               <Insets left="10.0" right="10.0" />
-            </padding>
-            <Label text="Panel de Gestión de Envíos" styleClass="header-title">
-               <font>
-                  <Font size="24.0" />
-               </font>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding><Insets left="10.0" right="10.0"/></padding>
+            <Label text="Lista de Envíos" styleClass="header-title">
+               <font><Font size="24.0"/></font>
             </Label>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+            <Label text="ID de Orden:"/>
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
          </HBox>
          <Separator/>
       </VBox>
@@ -33,26 +34,7 @@
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox>
-            <Label text="Filtros de Búsqueda">
-            </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0">
-               <padding>
-                  <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
-               </padding>
-               <Label text="ID de Orden:">
-               </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Ingrese el ID de la orden..."/>
-               <Button text="Buscar" onAction="#call_Buscar"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
-            </HBox>
-         </VBox>
-
          <VBox VBox.vgrow="ALWAYS">
-            <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="Lista de Envíos">
-               </Label>
-            </HBox>
             <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="60.0" text="ID"/>

--- a/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
+++ b/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
@@ -130,8 +130,4 @@ public class Lst_Envios_GuiController implements Initializable {
         }
     }
 
-    public void call_Limpiar(){
-        txt_Buscar.clear();
-        call_Buscar();
-    }
 }

--- a/src/proyectobd/EnviosGui/Mnt_Envios_Gui.fxml
+++ b/src/proyectobd/EnviosGui/Mnt_Envios_Gui.fxml
@@ -1,58 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <?import java.net.URL?>
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
-<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.EnviosGui.Mnt_Envios_GuiController">
-    <stylesheets>
-        <URL value="@/proyectobd/styles/app.css" />
-    </stylesheets>
-    <children>
-        <Pane prefHeight="50.0" prefWidth="800.0" styleClass="header-section">
-            <children>
-                <Label layoutX="240.0" layoutY="12.0" text="Formulario de Mantenimiento de Envíos" styleClass="header-title">
-                    <font>
-                        <Font size="24.0" />
-                    </font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="350.0" prefWidth="800.0" text="Detalles" animated="false">
-            <content>
-                <AnchorPane prefHeight="330.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Label layoutX="170.0" layoutY="40.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="220.0" layoutY="36.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="142.0" layoutY="76.0" text="Orden:" />
-                        <ComboBox fx:id="cmb_orden" layoutX="220.0" layoutY="72.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="126.0" layoutY="112.0" text="Dirección:" />
-                        <ComboBox fx:id="cmb_direccion" layoutX="220.0" layoutY="108.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="134.0" layoutY="148.0" text="Empresa:" />
-                        <TextField fx:id="txt_empresa" layoutX="220.0" layoutY="144.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="126.0" layoutY="184.0" text="Tracking:" />
-                        <TextField fx:id="txt_tracking" layoutX="220.0" layoutY="180.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="122.0" layoutY="220.0" text="Fecha Envio:" />
-                        <DatePicker fx:id="dp_envio" layoutX="220.0" layoutY="216.0" prefWidth="400.0" />
-                        <Label layoutX="88.0" layoutY="256.0" text="Fecha Estimada:" />
-                        <DatePicker fx:id="dp_estimada" layoutX="220.0" layoutY="252.0" prefWidth="400.0" />
-                        <Label layoutX="108.0" layoutY="292.0" text="Fecha Entrega:" />
-                        <DatePicker fx:id="dp_entrega" layoutX="220.0" layoutY="288.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="389.0" prefHeight="61.0" prefWidth="800.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.EnviosGui.Mnt_Envios_GuiController">
+   <stylesheets>
+      <URL value="@/proyectobd/styles/app.css" />
+   </stylesheets>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento de Envíos" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="120.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Orden:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_orden" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Dirección:" GridPane.rowIndex="2" />
+                  <ComboBox fx:id="cmb_direccion" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Empresa:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_empresa" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Tracking:" GridPane.rowIndex="4" />
+                  <TextField fx:id="txt_tracking" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                  <Label text="Fecha Envio:" GridPane.rowIndex="5" />
+                  <DatePicker fx:id="dp_envio" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                  <Label text="Fecha Estimada:" GridPane.rowIndex="6" />
+                  <DatePicker fx:id="dp_estimada" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+                  <Label text="Fecha Entrega:" GridPane.rowIndex="7" />
+                  <DatePicker fx:id="dp_entrega" GridPane.columnIndex="1" GridPane.rowIndex="7" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/ImagenesProductoGui/Lst_ImagenesProducto_Gui.fxml
+++ b/src/proyectobd/ImagenesProductoGui/Lst_ImagenesProducto_Gui.fxml
@@ -13,15 +13,16 @@
       <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
    <top>
       <VBox>
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-section">
-            <padding>
-               <Insets left="10.0" right="10.0" />
-            </padding>
-            <Label text="Panel de Gestión de Imágenes de Producto" styleClass="header-title">
-               <font>
-                  <Font size="24.0" />
-               </font>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding><Insets left="10.0" right="10.0"/></padding>
+            <Label text="Lista de Imágenes de Producto" styleClass="header-title">
+               <font><Font size="24.0"/></font>
             </Label>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+            <Label text="Producto ID:"/>
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
          </HBox>
          <Separator />
       </VBox>
@@ -33,26 +34,7 @@
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox>
-            <Label text="Filtros de Búsqueda">
-            </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0">
-               <padding>
-                  <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
-               </padding>
-               <Label text="Producto ID:">
-               </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
-               <Button text="Buscar" onAction="#call_Buscar"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
-            </HBox>
-         </VBox>
-
          <VBox VBox.vgrow="ALWAYS">
-            <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="Lista de Imágenes">
-               </Label>
-            </HBox>
             <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>

--- a/src/proyectobd/ImagenesProductoGui/Lst_ImagenesProducto_GuiController.java
+++ b/src/proyectobd/ImagenesProductoGui/Lst_ImagenesProducto_GuiController.java
@@ -124,8 +124,4 @@ public class Lst_ImagenesProducto_GuiController implements Initializable {
         }
     }
 
-    public void call_Limpiar(){
-        txt_Buscar.clear();
-        call_Buscar();
-    }
 }

--- a/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml
+++ b/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml
@@ -1,49 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ImagenesProductoGui.Mnt_ImagenesProducto_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ImagenesProductoGui.Mnt_ImagenesProducto_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="50.0" prefWidth="600.0" styleClass="header-section">
-            <children>
-                <Label layoutX="150.0" layoutY="12.0" text="Formulario de Mantenimiento de Imágenes de Producto" styleClass="header-title">
-                    <font>
-                        <Font size="24.0" />
-                    </font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
-            <content>
-                <AnchorPane prefHeight="230.0" prefWidth="598.0">
-                    <children>
-                        <Label layoutX="96.0" layoutY="36.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="160.0" layoutY="32.0" prefWidth="400.0" />
-                        <Label layoutX="48.0" layoutY="72.0" text="Producto:" />
-                        <ComboBox fx:id="cmb_producto" layoutX="160.0" layoutY="68.0" prefWidth="400.0" />
-                        <Label layoutX="116.0" layoutY="108.0" text="URL:" />
-                        <TextField fx:id="txt_url" layoutX="160.0" layoutY="104.0" prefWidth="400.0" />
-                        <Label layoutX="80.0" layoutY="144.0" text="Principal:" />
-                        <TextField fx:id="txt_principal" layoutX="160.0" layoutY="140.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="289.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane>
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Imágenes Producto" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="100.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Producto:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_producto" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="URL:" GridPane.rowIndex="2" />
+                  <TextField fx:id="txt_url" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Principal:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_principal" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_Gui.fxml
+++ b/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_Gui.fxml
@@ -4,57 +4,65 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
+<?import javafx.geometry.Insets?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ListaDeseoItemsGui.Lst_ListaDeseoItems_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="300.0" layoutY="3.0" text="Items de Lista" styleClass="header-title">
+      <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+   <top>
+      <VBox>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding>
+               <Insets left="10.0" right="10.0"/>
+            </padding>
+            <Label text="Items de Lista" styleClass="header-title">
                <font><Font size="24.0" /></font>
             </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Lista ID:" />
-                  <TextField fx:id="txt_Buscar" layoutX="110.0" layoutY="18.0" prefHeight="25.0" prefWidth="590.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
-                      <TableColumn fx:id="col_lista" prefWidth="75.0" text="Lista" />
-                      <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante" />
-                      <TableColumn fx:id="col_cantidad" prefWidth="75.0" text="Cantidad" />
-                    </columns>
-                    <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Label text="Lista ID:" />
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
+         </HBox>
+         <Separator />
+      </VBox>
+   </top>
+   <center>
+      <VBox spacing="5.0">
+         <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+         </padding>
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+            <columns>
+              <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
+              <TableColumn fx:id="col_lista" prefWidth="75.0" text="Lista" />
+              <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante" />
+              <TableColumn fx:id="col_cantidad" prefWidth="75.0" text="Cantidad" />
+            </columns>
+            <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
+         </TableView>
+      </VBox>
+   </center>
+   <bottom>
+      <VBox>
+         <Separator />
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Region HBox.hgrow="ALWAYS" />
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+         </HBox>
+      </VBox>
+   </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/ListaDeseoItemsGui/Mnt_ListaDeseoItems_Gui.fxml
+++ b/src/proyectobd/ListaDeseoItemsGui/Mnt_ListaDeseoItems_Gui.fxml
@@ -1,47 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ListaDeseoItemsGui.Mnt_ListaDeseoItems_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ListaDeseoItemsGui.Mnt_ListaDeseoItems_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="39.0" prefWidth="600.0" styleClass="header-section">
-            <children>
-                <Label layoutX="160.0" layoutY="2.0" text="Mantenimiento Items Lista" styleClass="header-title">
-                    <font><Font size="24.0"/></font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
-            <content>
-                <AnchorPane prefHeight="230.0" prefWidth="598.0">
-                    <children>
-                        <Label layoutX="96.0" layoutY="36.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="160.0" layoutY="32.0" prefWidth="400.0" />
-                        <Label layoutX="56.0" layoutY="72.0" text="Lista:" />
-                        <ComboBox fx:id="cmb_lista" layoutX="160.0" layoutY="68.0" prefWidth="400.0" />
-                        <Label layoutX="48.0" layoutY="108.0" text="Variante:" />
-                        <ComboBox fx:id="cmb_variante" layoutX="160.0" layoutY="104.0" prefWidth="400.0" />
-                        <Label layoutX="92.0" layoutY="144.0" text="Cantidad:" />
-                        <TextField fx:id="txt_cantidad" layoutX="160.0" layoutY="140.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="289.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane>
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento Items Lista" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="80.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Lista:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_lista" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Variante:" GridPane.rowIndex="2" />
+                  <ComboBox fx:id="cmb_variante" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Cantidad:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_cantidad" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/ListasDeseosGui/Lst_ListasDeseos_Gui.fxml
+++ b/src/proyectobd/ListasDeseosGui/Lst_ListasDeseos_Gui.fxml
@@ -4,61 +4,69 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
+<?import javafx.geometry.Insets?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ListasDeseosGui.Lst_ListasDeseos_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="314.0" layoutY="3.0" text="Listas de Deseos" styleClass="header-title">
+      <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+   <top>
+      <VBox>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding>
+               <Insets left="10.0" right="10.0"/>
+            </padding>
+            <Label text="Listas de Deseos" styleClass="header-title">
                <font>
                   <Font size="24.0" />
                </font>
             </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0">
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Buscar:" />
-                  <TextField fx:id="txt_Buscar" layoutX="75.0" layoutY="18.0" prefHeight="25.0" prefWidth="624.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0">
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-                      <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
-                      <TableColumn fx:id="col_nombre" prefWidth="150.0" text="Nombre" />
-                      <TableColumn fx:id="col_creado" prefWidth="150.0" text="Creado" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane prefHeight="27.0" prefWidth="479.0">
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" text="Cerrar" mnemonicParsing="false" onAction="#call_CerrarVentana" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Label text="Buscar:" />
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
+         </HBox>
+         <Separator />
+      </VBox>
+   </top>
+   <center>
+      <VBox spacing="5.0">
+         <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+         </padding>
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+            <columns>
+              <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
+              <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
+              <TableColumn fx:id="col_nombre" prefWidth="150.0" text="Nombre" />
+              <TableColumn fx:id="col_creado" prefWidth="150.0" text="Creado" />
+            </columns>
+            <columnResizePolicy>
+               <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+            </columnResizePolicy>
+         </TableView>
+      </VBox>
+   </center>
+   <bottom>
+      <VBox>
+         <Separator />
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Region HBox.hgrow="ALWAYS" />
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+         </HBox>
+      </VBox>
+   </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/ListasDeseosGui/Mnt_ListasDeseos_Gui.fxml
+++ b/src/proyectobd/ListasDeseosGui/Mnt_ListasDeseos_Gui.fxml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
-<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
@@ -11,21 +10,39 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane prefHeight="39.0" prefWidth="400.0" styleClass="header-section">
-         <children>
-            <Label layoutX="124.0" layoutY="7.0" text="Lista Deseos" styleClass="header-title">
-               <font>
-                  <Font size="18.0" />
-               </font>
-            </Label>
-         </children>
-      </Pane>
-      <Label layoutX="32.0" layoutY="67.0" text="Usuario:" />
-      <ComboBox fx:id="cmb_usuario" layoutX="98.0" layoutY="63.0" prefWidth="250.0" />
-      <Label layoutX="32.0" layoutY="88.0" text="Nombre:" />
-      <TextField fx:id="txt_nombre" layoutX="98.0" layoutY="84.0" prefWidth="250.0" />
-      <Label layoutX="32.0" layoutY="108.0" text="Creado:" />
-      <DatePicker fx:id="dp_creado" layoutX="98.0" layoutY="104.0" prefWidth="250.0" />
-      <Button fx:id="btn_Guardar" layoutX="154.0" layoutY="164.0" mnemonicParsing="false" onAction="#call_Guardar" text="Guardar" />
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Lista Deseos" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="70.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="Usuario:" />
+                  <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1" />
+                  <Label text="Nombre:" GridPane.rowIndex="1" />
+                  <TextField fx:id="txt_nombre" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Creado:" GridPane.rowIndex="2" />
+                  <DatePicker fx:id="dp_creado" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Guardar" onAction="#call_Guardar" text="Guardar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/OfertasGui/Lst_Ofertas_Gui.fxml
+++ b/src/proyectobd/OfertasGui/Lst_Ofertas_Gui.fxml
@@ -13,15 +13,16 @@
       <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
    <top>
       <VBox>
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-section">
-            <padding>
-               <Insets left="10.0" right="10.0" />
-            </padding>
-            <Label text="Panel de Gestión de Ofertas Promocionales" styleClass="header-title">
-               <font>
-                  <Font size="24.0" />
-               </font>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding><Insets left="10.0" right="10.0"/></padding>
+            <Label text="Lista de Ofertas" styleClass="header-title">
+               <font><Font size="24.0"/></font>
             </Label>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+            <Label text="Variante ID:"/>
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
          </HBox>
          <Separator />
       </VBox>
@@ -33,26 +34,7 @@
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox>
-            <Label text="Filtros de Búsqueda">
-            </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0">
-               <padding>
-                  <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
-               </padding>
-               <Label text="Variante ID:">
-               </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
-               <Button text="Buscar" onAction="#call_Buscar"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
-            </HBox>
-         </VBox>
-
          <VBox VBox.vgrow="ALWAYS">
-            <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="Lista de Ofertas">
-               </Label>
-            </HBox>
             <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>

--- a/src/proyectobd/OfertasGui/Lst_Ofertas_GuiController.java
+++ b/src/proyectobd/OfertasGui/Lst_Ofertas_GuiController.java
@@ -127,8 +127,4 @@ public class Lst_Ofertas_GuiController implements Initializable {
         }
     }
 
-    public void call_Limpiar(){
-        txt_Buscar.clear();
-        call_Buscar();
-    }
 }

--- a/src/proyectobd/OfertasGui/Mnt_Ofertas_Gui.fxml
+++ b/src/proyectobd/OfertasGui/Mnt_Ofertas_Gui.fxml
@@ -1,52 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
-<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OfertasGui.Mnt_Ofertas_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OfertasGui.Mnt_Ofertas_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="50.0" prefWidth="600.0" styleClass="header-section">
-            <children>
-                <Label layoutX="190.0" layoutY="12.0" text="Formulario de Mantenimiento de Ofertas" styleClass="header-title">
-                    <font>
-                        <Font size="24.0" />
-                    </font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
-            <content>
-                <AnchorPane prefHeight="230.0" prefWidth="598.0">
-                    <children>
-                        <Label layoutX="96.0" layoutY="36.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="160.0" layoutY="32.0" prefWidth="400.0" />
-                        <Label layoutX="48.0" layoutY="72.0" text="Variante:" />
-                        <ComboBox fx:id="cmb_variante" layoutX="160.0" layoutY="68.0" prefWidth="400.0" />
-                        <Label layoutX="72.0" layoutY="108.0" text="Descuento:" />
-                        <TextField fx:id="txt_precio" layoutX="160.0" layoutY="104.0" prefWidth="400.0" />
-                        <Label layoutX="100.0" layoutY="144.0" text="Inicio:" />
-                        <DatePicker fx:id="dp_inicio" layoutX="160.0" layoutY="140.0" prefWidth="400.0" />
-                        <Label layoutX="116.0" layoutY="180.0" text="Fin:" />
-                        <DatePicker fx:id="dp_fin" layoutX="160.0" layoutY="176.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="289.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane>
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento de Ofertas" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="100.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Variante:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_variante" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Descuento:" GridPane.rowIndex="2" />
+                  <TextField fx:id="txt_precio" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Inicio:" GridPane.rowIndex="3" />
+                  <DatePicker fx:id="dp_inicio" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Fin:" GridPane.rowIndex="4" />
+                  <DatePicker fx:id="dp_fin" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/OrdenItemsGui/Lst_OrdenItems_Gui.fxml
+++ b/src/proyectobd/OrdenItemsGui/Lst_OrdenItems_Gui.fxml
@@ -4,57 +4,65 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
+<?import javafx.geometry.Insets?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OrdenItemsGui.Lst_OrdenItems_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="300.0" layoutY="3.0" text="Items de Orden" styleClass="header-title">
+      <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+   <top>
+      <VBox>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding>
+               <Insets left="10.0" right="10.0"/>
+            </padding>
+            <Label text="Items de Orden" styleClass="header-title">
                <font><Font size="24.0" /></font>
             </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Orden ID:" />
-                  <TextField fx:id="txt_Buscar" layoutX="110.0" layoutY="18.0" prefHeight="25.0" prefWidth="590.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
-                      <TableColumn fx:id="col_orden" prefWidth="75.0" text="Orden" />
-                      <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante" />
-                      <TableColumn fx:id="col_cantidad" prefWidth="75.0" text="Cantidad" />
-                    </columns>
-                    <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Label text="Orden ID:" />
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
+         </HBox>
+         <Separator />
+      </VBox>
+   </top>
+   <center>
+      <VBox spacing="5.0">
+         <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+         </padding>
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+            <columns>
+              <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
+              <TableColumn fx:id="col_orden" prefWidth="75.0" text="Orden" />
+              <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante" />
+              <TableColumn fx:id="col_cantidad" prefWidth="75.0" text="Cantidad" />
+            </columns>
+            <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
+         </TableView>
+      </VBox>
+   </center>
+   <bottom>
+      <VBox>
+         <Separator />
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Region HBox.hgrow="ALWAYS" />
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+         </HBox>
+      </VBox>
+   </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/OrdenItemsGui/Mnt_OrdenItems_Gui.fxml
+++ b/src/proyectobd/OrdenItemsGui/Mnt_OrdenItems_Gui.fxml
@@ -1,47 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OrdenItemsGui.Mnt_OrdenItems_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OrdenItemsGui.Mnt_OrdenItems_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="39.0" prefWidth="600.0" styleClass="header-section">
-            <children>
-                <Label layoutX="160.0" layoutY="2.0" text="Mantenimiento Items Orden" styleClass="header-title">
-                    <font><Font size="24.0"/></font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
-            <content>
-                <AnchorPane prefHeight="230.0" prefWidth="598.0">
-                    <children>
-                        <Label layoutX="96.0" layoutY="36.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="160.0" layoutY="32.0" prefWidth="400.0" />
-                        <Label layoutX="56.0" layoutY="72.0" text="Orden:" />
-                        <ComboBox fx:id="cmb_orden" layoutX="160.0" layoutY="68.0" prefWidth="400.0" />
-                        <Label layoutX="48.0" layoutY="108.0" text="Variante:" />
-                        <ComboBox fx:id="cmb_variante" layoutX="160.0" layoutY="104.0" prefWidth="400.0" />
-                        <Label layoutX="92.0" layoutY="144.0" text="Cantidad:" />
-                        <TextField fx:id="txt_cantidad" layoutX="160.0" layoutY="140.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="289.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane>
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento Items Orden" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="80.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Orden:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_orden" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Variante:" GridPane.rowIndex="2" />
+                  <ComboBox fx:id="cmb_variante" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Cantidad:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_cantidad" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/OrdenesGui/Lst_Ordenes_Gui.fxml
+++ b/src/proyectobd/OrdenesGui/Lst_Ordenes_Gui.fxml
@@ -1,71 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
 
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TableColumn?>
-<?import javafx.scene.control.TableView?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
+<?import javafx.geometry.Insets?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OrdenesGui.Lst_Ordenes_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="328.0" layoutY="3.0" text="Lista de Ordenes" styleClass="header-title">
+      <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+   <top>
+      <VBox>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding>
+               <Insets left="10.0" right="10.0"/>
+            </padding>
+            <Label text="Lista de Ordenes" styleClass="header-title">
                <font>
-                  <Font name="Courier New" size="24.0" />
+                  <Font size="24.0" />
                </font>
             </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Buscar:" />
-                  <TextField fx:id="txt_Buscar" layoutX="75.0" layoutY="18.0" prefHeight="25.0" prefWidth="624.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-                      <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
-                      <TableColumn fx:id="col_estado" prefWidth="100.0" text="Estado" />
-                      <TableColumn fx:id="col_total" prefWidth="100.0" text="Total" />
-                      <TableColumn fx:id="col_fecha" prefWidth="150.0" text="Fecha" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane prefHeight="27.0" prefWidth="479.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" text="Cerrar" mnemonicParsing="false" onAction="#call_CerrarVentana" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Label text="Buscar:" />
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
+         </HBox>
+         <Separator />
+      </VBox>
+   </top>
+   <center>
+      <VBox spacing="5.0">
+         <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+         </padding>
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+            <columns>
+              <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
+              <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
+              <TableColumn fx:id="col_estado" prefWidth="100.0" text="Estado" />
+              <TableColumn fx:id="col_total" prefWidth="100.0" text="Total" />
+              <TableColumn fx:id="col_fecha" prefWidth="150.0" text="Fecha" />
+            </columns>
+            <columnResizePolicy>
+               <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+            </columnResizePolicy>
+         </TableView>
+      </VBox>
+   </center>
+   <bottom>
+      <VBox>
+         <Separator />
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Region HBox.hgrow="ALWAYS" />
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+         </HBox>
+      </VBox>
+   </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/OrdenesGui/Mnt_Ordenes_Gui.fxml
+++ b/src/proyectobd/OrdenesGui/Mnt_Ordenes_Gui.fxml
@@ -1,59 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.control.ComboBox?>
-<?import javafx.scene.control.DatePicker?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OrdenesGui.Mnt_Ordenes_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.OrdenesGui.Mnt_Ordenes_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-            <children>
-                <Label layoutX="225.0" layoutY="2.0" text="Mantenimiento de Órdenes" styleClass="header-title">
-                    <font>
-                        <Font name="Courier New" size="24.0" />
-                    </font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="300.0" prefWidth="800.0" text="Detalles del Registro" animated="false">
-            <content>
-                <AnchorPane prefHeight="280.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Label layoutX="170.0" layoutY="40.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="220.0" layoutY="36.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="126.0" layoutY="76.0" text="Usuario:" />
-                        <ComboBox fx:id="cmb_usuario" layoutX="220.0" layoutY="72.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="160.0" layoutY="112.0" text="Estado:" />
-                        <ComboBox fx:id="cmb_estado" layoutX="220.0" layoutY="108.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="144.0" layoutY="148.0" text="Total Bruto:" />
-                        <TextField fx:id="txt_totalbruto" layoutX="220.0" layoutY="144.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="122.0" layoutY="184.0" text="Total Descuento:" />
-                        <TextField fx:id="txt_totaldescuento" layoutX="220.0" layoutY="180.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="146.0" layoutY="220.0" text="Fecha:" />
-                        <DatePicker fx:id="dp_fecha" layoutX="220.0" layoutY="216.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="339.0" prefHeight="61.0" prefWidth="800.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento de Órdenes" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="120.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Usuario:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Estado:" GridPane.rowIndex="2" />
+                  <ComboBox fx:id="cmb_estado" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Total Bruto:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_totalbruto" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Total Descuento:" GridPane.rowIndex="4" />
+                  <TextField fx:id="txt_totaldescuento" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                  <Label text="Fecha:" GridPane.rowIndex="5" />
+                  <DatePicker fx:id="dp_fecha" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/PagosGui/Lst_Pagos_Gui.fxml
+++ b/src/proyectobd/PagosGui/Lst_Pagos_Gui.fxml
@@ -4,58 +4,66 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
+<?import javafx.geometry.Insets?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.PagosGui.Lst_Pagos_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="300.0" layoutY="3.0" text="Pagos" styleClass="header-title">
+      <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+   <top>
+      <VBox>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding>
+               <Insets left="10.0" right="10.0"/>
+            </padding>
+            <Label text="Pagos" styleClass="header-title">
                <font><Font size="24.0" /></font>
             </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Orden ID:" />
-                  <TextField fx:id="txt_Buscar" layoutX="110.0" layoutY="18.0" prefHeight="25.0" prefWidth="590.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
-                      <TableColumn fx:id="col_orden" prefWidth="75.0" text="Orden" />
-                      <TableColumn fx:id="col_metodo" prefWidth="100.0" text="Metodo" />
-                      <TableColumn fx:id="col_monto" prefWidth="75.0" text="Monto" />
-                      <TableColumn fx:id="col_fecha" prefWidth="150.0" text="Fecha" />
-                    </columns>
-                    <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane>
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Label text="Orden ID:" />
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
+         </HBox>
+         <Separator />
+      </VBox>
+   </top>
+   <center>
+      <VBox spacing="5.0">
+         <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+         </padding>
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+            <columns>
+              <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
+              <TableColumn fx:id="col_orden" prefWidth="75.0" text="Orden" />
+              <TableColumn fx:id="col_metodo" prefWidth="100.0" text="Metodo" />
+              <TableColumn fx:id="col_monto" prefWidth="75.0" text="Monto" />
+              <TableColumn fx:id="col_fecha" prefWidth="150.0" text="Fecha" />
+            </columns>
+            <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
+         </TableView>
+      </VBox>
+   </center>
+   <bottom>
+      <VBox>
+         <Separator />
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Region HBox.hgrow="ALWAYS" />
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+         </HBox>
+      </VBox>
+   </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/PagosGui/Mnt_Pagos_Gui.fxml
+++ b/src/proyectobd/PagosGui/Mnt_Pagos_Gui.fxml
@@ -1,50 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
-<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.PagosGui.Mnt_Pagos_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.PagosGui.Mnt_Pagos_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="39.0" prefWidth="600.0" styleClass="header-section">
-            <children>
-                <Label layoutX="160.0" layoutY="2.0" text="Mantenimiento Pagos" styleClass="header-title">
-                    <font><Font size="24.0"/></font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
-            <content>
-                <AnchorPane prefHeight="230.0" prefWidth="598.0">
-                    <children>
-                        <Label layoutX="96.0" layoutY="36.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="160.0" layoutY="32.0" prefWidth="400.0" />
-                        <Label layoutX="56.0" layoutY="72.0" text="Orden:" />
-                        <ComboBox fx:id="cmb_orden" layoutX="160.0" layoutY="68.0" prefWidth="400.0" />
-                        <Label layoutX="48.0" layoutY="108.0" text="Metodo:" />
-                        <TextField fx:id="txt_metodo" layoutX="160.0" layoutY="104.0" prefWidth="400.0" />
-                        <Label layoutX="92.0" layoutY="144.0" text="Monto:" />
-                        <TextField fx:id="txt_monto" layoutX="160.0" layoutY="140.0" prefWidth="400.0" />
-                        <Label layoutX="96.0" layoutY="176.0" text="Fecha:" />
-                        <DatePicker fx:id="dp_fecha" layoutX="160.0" layoutY="172.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="289.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane>
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento Pagos" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="80.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Orden:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_orden" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Metodo:" GridPane.rowIndex="2" />
+                  <TextField fx:id="txt_metodo" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Monto:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_monto" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Fecha:" GridPane.rowIndex="4" />
+                  <DatePicker fx:id="dp_fecha" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/ResenasGui/Lst_Resenas_Gui.fxml
+++ b/src/proyectobd/ResenasGui/Lst_Resenas_Gui.fxml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ResenasGui.Lst_Resenas_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ResenasGui.Lst_Resenas_GuiController">
+   <stylesheets>
+      <URL value="@/proyectobd/styles/app.css" />
+   </stylesheets>
    <children>
       <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
    <top>
@@ -17,7 +21,7 @@
          </HBox>
          <HBox alignment="CENTER_LEFT" spacing="10.0">
             <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
-            <Label text="ID de Reseña:"/>
+            <Label text="Buscar:"/>
             <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
          </HBox>
          <Separator/>
@@ -25,13 +29,11 @@
    </top>
 
    <center>
-      <VBox spacing="10.0">
+      <VBox spacing="5.0">
          <padding>
-            <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
          </padding>
-
-         <VBox VBox.vgrow="ALWAYS">
-            <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
                   <TableColumn fx:id="col_producto" prefWidth="75.0" text="Producto"/>
@@ -43,7 +45,6 @@
                   <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
                </columnResizePolicy>
             </TableView>
-         </VBox>
       </VBox>
    </center>
 
@@ -52,7 +53,7 @@
          <Separator/>
          <HBox alignment="CENTER_RIGHT" spacing="10.0">
             <padding>
-               <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
             </padding>
             <Region HBox.hgrow="ALWAYS"/>
             <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>

--- a/src/proyectobd/ResenasGui/Lst_Resenas_Gui.fxml
+++ b/src/proyectobd/ResenasGui/Lst_Resenas_Gui.fxml
@@ -9,9 +9,16 @@
       <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
    <top>
       <VBox>
-         <HBox alignment="CENTER" prefHeight="60.0">
-            <Label text="Panel de Gestión de Reseñas">
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding><Insets left="10.0" right="10.0"/></padding>
+            <Label text="Lista de Reseñas" styleClass="header-title">
+               <font><Font size="24.0"/></font>
             </Label>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+            <Label text="ID de Reseña:"/>
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
          </HBox>
          <Separator/>
       </VBox>
@@ -23,26 +30,7 @@
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox>
-            <Label text="Filtros de Búsqueda">
-            </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0">
-               <padding>
-                  <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
-               </padding>
-               <Label text="ID de Reseña:">
-               </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
-               <Button text="Buscar" onAction="#call_Buscar"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
-            </HBox>
-         </VBox>
-
          <VBox VBox.vgrow="ALWAYS">
-            <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="Lista de Reseñas">
-               </Label>
-            </HBox>
             <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>

--- a/src/proyectobd/ResenasGui/Lst_Resenas_GuiController.java
+++ b/src/proyectobd/ResenasGui/Lst_Resenas_GuiController.java
@@ -127,8 +127,4 @@ public class Lst_Resenas_GuiController implements Initializable {
         }
     }
 
-    public void call_Limpiar(){
-        txt_Buscar.clear();
-        call_Buscar();
-    }
 }

--- a/src/proyectobd/ResenasGui/Mnt_Resenas_Gui.fxml
+++ b/src/proyectobd/ResenasGui/Mnt_Resenas_Gui.fxml
@@ -1,51 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.control.ComboBox?>
-<?import javafx.scene.control.DatePicker?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ResenasGui.Mnt_Resenas_GuiController">
-    <children>
-        <Pane prefHeight="50.0" prefWidth="800.0">
-            <children>
-                <Label layoutX="240.0" layoutY="12.0" text="Formulario de Mantenimiento de Reseñas" />
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="300.0" prefWidth="800.0" text="Detalles del Registro" animated="false">
-            <content>
-                <AnchorPane prefHeight="280.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Label layoutX="170.0" layoutY="40.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="220.0" layoutY="36.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="126.0" layoutY="76.0" text="Producto:" />
-                        <ComboBox fx:id="cmb_producto" layoutX="220.0" layoutY="72.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="134.0" layoutY="112.0" text="Usuario:" />
-                        <ComboBox fx:id="cmb_usuario" layoutX="220.0" layoutY="108.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="160.0" layoutY="148.0" text="Rating:" />
-                        <ComboBox fx:id="cmb_rating" layoutX="220.0" layoutY="144.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="139.0" layoutY="184.0" text="Comentario:" />
-                        <TextField fx:id="txt_comentario" layoutX="220.0" layoutY="180.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="176.0" layoutY="220.0" text="Fecha:" />
-                        <DatePicker fx:id="dp_fecha" layoutX="220.0" layoutY="216.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="339.0" prefHeight="61.0" prefWidth="800.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.ResenasGui.Mnt_Resenas_GuiController">
+   <stylesheets>
+      <URL value="@/proyectobd/styles/app.css" />
+   </stylesheets>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento de Reseñas" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="120.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Producto:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_producto" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Usuario:" GridPane.rowIndex="2" />
+                  <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Rating:" GridPane.rowIndex="3" />
+                  <ComboBox fx:id="cmb_rating" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Comentario:" GridPane.rowIndex="4" />
+                  <TextField fx:id="txt_comentario" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                  <Label text="Fecha:" GridPane.rowIndex="5" />
+                  <DatePicker fx:id="dp_fecha" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/RolesGui/Lst_Roles_Gui.fxml
+++ b/src/proyectobd/RolesGui/Lst_Roles_Gui.fxml
@@ -1,68 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
 
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TableColumn?>
-<?import javafx.scene.control.TableView?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
+<?import javafx.geometry.Insets?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.RolesGui.Lst_Roles_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="328.0" layoutY="3.0" text="Lista de Roles" styleClass="header-title">
+      <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+   <top>
+      <VBox>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding>
+               <Insets left="10.0" right="10.0"/>
+            </padding>
+            <Label text="Lista de Roles" styleClass="header-title">
                <font>
                   <Font size="24.0" />
                </font>
             </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Buscar:" />
-                  <TextField fx:id="txt_Buscar" layoutX="75.0" layoutY="18.0" prefHeight="25.0" prefWidth="624.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-                      <TableColumn fx:id="col_nombre" prefWidth="200.0" text="Nombre" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane prefHeight="27.0" prefWidth="479.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" text="Cerrar" mnemonicParsing="false" onAction="#call_CerrarVentana" />
-              </children>
-           </AnchorPane>
-        </content>
-      </TitledPane>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Label text="Buscar:" />
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
+         </HBox>
+         <Separator />
+      </VBox>
+   </top>
+   <center>
+      <VBox spacing="5.0">
+         <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+         </padding>
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+            <columns>
+              <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
+              <TableColumn fx:id="col_nombre" prefWidth="200.0" text="Nombre" />
+            </columns>
+            <columnResizePolicy>
+               <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+            </columnResizePolicy>
+         </TableView>
+      </VBox>
+   </center>
+   <bottom>
+      <VBox>
+         <Separator />
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Region HBox.hgrow="ALWAYS" />
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+         </HBox>
+      </VBox>
+   </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/RolesGui/Mnt_Roles_Gui.fxml
+++ b/src/proyectobd/RolesGui/Mnt_Roles_Gui.fxml
@@ -1,50 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.RolesGui.Mnt_Roles_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.RolesGui.Mnt_Roles_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-            <children>
-                <Label layoutX="220.0" layoutY="2.0" text="Mantenimiento de Roles" styleClass="header-title">
-                    <font>
-                        <Font size="24.0" />
-                    </font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="200.0" prefWidth="800.0" text="Detalles del Registro" animated="false">
-            <content>
-                <AnchorPane prefHeight="180.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Label layoutX="170.0" layoutY="40.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="220.0" layoutY="36.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="146.0" layoutY="76.0" text="Nombre:" />
-                        <TextField fx:id="txt_nombre" layoutX="220.0" layoutY="72.0" prefHeight="25.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="239.0" prefHeight="61.0" prefWidth="800.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Borrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                        <Button fx:id="btn_Cerrar" layoutX="693.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento de Roles" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="80.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Nombre:" GridPane.rowIndex="1" />
+                  <TextField fx:id="txt_nombre" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/UsuariosGui/Lst_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Lst_Usuarios_Gui.fxml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TableColumn?>
-<?import javafx.scene.control.TableView?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Lst_Usuarios_GuiController">
@@ -16,55 +10,50 @@
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="330.0" layoutY="3.0" text="Lista de Usuarios" styleClass="header-title">
-               <font>
-                  <Font name="Arial Black" size="24.0" />
-               </font>
-            </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Buscar:" />
-                  <TextField fx:id="txt_Buscar" layoutX="75.0" layoutY="18.0" prefHeight="25.0" prefWidth="624.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-                      <TableColumn fx:id="col_rol" prefWidth="75.0" text="Rol" />
-                      <TableColumn fx:id="col_nombre" prefWidth="150.0" text="Nombre" />
-                      <TableColumn fx:id="col_email" prefWidth="200.0" text="Email" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane prefHeight="27.0" prefWidth="479.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" text="Cerrar" mnemonicParsing="false" onAction="#call_CerrarVentana" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+      <BorderPane AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <VBox>
+               <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+                  <padding><Insets left="10.0" right="10.0"/></padding>
+                  <Label text="Lista de Usuarios" styleClass="header-title">
+                     <font><Font size="24.0"/></font>
+                  </Label>
+               </HBox>
+               <HBox alignment="CENTER_LEFT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Label text="Buscar:"/>
+                  <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS"/>
+               </HBox>
+               <Separator/>
+            </VBox>
+         </top>
+         <center>
+            <VBox spacing="5.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+                  <columns>
+                     <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
+                     <TableColumn fx:id="col_rol" prefWidth="75.0" text="Rol"/>
+                     <TableColumn fx:id="col_nombre" prefWidth="150.0" text="Nombre"/>
+                     <TableColumn fx:id="col_email" prefWidth="200.0" text="Email"/>
+                  </columns>
+                  <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>
+               </TableView>
+            </VBox>
+         </center>
+         <bottom>
+            <VBox>
+               <Separator/>
+               <HBox alignment="CENTER_RIGHT" spacing="10.0">
+                  <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+                  <Region HBox.hgrow="ALWAYS"/>
+                  <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
+                  <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
+                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
+                  <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+               </HBox>
+            </VBox>
+         </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
@@ -1,62 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.PasswordField?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.control.ComboBox?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="480.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Mnt_Usuarios_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="480.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Mnt_Usuarios_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="39.0" prefWidth="600.0" styleClass="header-section">
-            <children>
-                <Label layoutX="120.0" layoutY="2.0" text="Mantenimiento de Usuarios" styleClass="header-title">
-                    <font>
-                        <Font name="Arial Black" size="24.0" />
-                    </font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="300.0" prefWidth="600.0" text="Detalles del Registro" animated="false">
-            <content>
-                <AnchorPane prefHeight="280.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <ImageView fx:id="img_perfil" fitHeight="150.0" fitWidth="150.0" layoutX="20.0" layoutY="24.0" pickOnBounds="true" preserveRatio="true" style="-fx-border-color: black; -fx-border-width: 1; -fx-background-color: lightgray;" />
-                        <Label layoutX="190.0" layoutY="28.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="230.0" layoutY="24.0" prefWidth="360.0" />
-                        <Label layoutX="168.0" layoutY="64.0" text="Rol:" />
-                        <ComboBox fx:id="cmb_rol" layoutX="230.0" layoutY="60.0" prefWidth="360.0" />
-                        <Label layoutX="160.0" layoutY="100.0" text="Nombre:" />
-                        <TextField fx:id="txt_nombre" layoutX="230.0" layoutY="96.0" prefWidth="360.0" />
-                        <Label layoutX="175.0" layoutY="136.0" text="Email:" />
-                        <TextField fx:id="txt_email" layoutX="230.0" layoutY="132.0" prefWidth="360.0" />
-                        <Label layoutX="136.0" layoutY="172.0" text="Contraseña:" />
-                        <PasswordField fx:id="txt_contrasena" layoutX="230.0" layoutY="168.0" prefWidth="360.0" />
-                        <Label layoutX="157.0" layoutY="204.0" text="Imagen:" />
-                        <TextField fx:id="txt_imagen" layoutX="230.0" layoutY="200.0" prefWidth="330.0" />
-                        <Button fx:id="btn_BuscarImagen" layoutX="560.0" layoutY="200.0" mnemonicParsing="false" onAction="#call_SeleccionarImagen" text="..." />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="339.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane prefHeight="27.0" prefWidth="598.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="445.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="514.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento de Usuarios" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="120.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <ImageView fx:id="img_perfil" fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true" style="-fx-border-color: black; -fx-border-width: 1; -fx-background-color: lightgray;" />
+                  <Label text="ID:" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="2" />
+                  <Label text="Rol:" GridPane.rowIndex="1" GridPane.columnIndex="1" />
+                  <ComboBox fx:id="cmb_rol" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+                  <Label text="Nombre:" GridPane.rowIndex="2" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_nombre" GridPane.columnIndex="2" GridPane.rowIndex="2" />
+                  <Label text="Email:" GridPane.rowIndex="3" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_email" GridPane.columnIndex="2" GridPane.rowIndex="3" />
+                  <Label text="Contraseña:" GridPane.rowIndex="4" GridPane.columnIndex="1" />
+                  <PasswordField fx:id="txt_contrasena" GridPane.columnIndex="2" GridPane.rowIndex="4" />
+                  <Label text="Imagen:" GridPane.rowIndex="5" GridPane.columnIndex="1" />
+                  <HBox spacing="5.0" GridPane.columnIndex="2" GridPane.rowIndex="5">
+                     <TextField fx:id="txt_imagen" HBox.hgrow="ALWAYS" />
+                     <Button fx:id="btn_BuscarImagen" onAction="#call_SeleccionarImagen" text="..." />
+                  </HBox>
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/VarianteProductoGui/Lst_VariantesProducto_Gui.fxml
+++ b/src/proyectobd/VarianteProductoGui/Lst_VariantesProducto_Gui.fxml
@@ -13,15 +13,16 @@
       <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
    <top>
       <VBox>
-         <HBox alignment="CENTER" prefHeight="60.0" styleClass="header-section">
-            <padding>
-               <Insets left="10.0" right="10.0" />
-            </padding>
-            <Label text="Panel de Gestión de Variantes de Producto" styleClass="header-title">
-               <font>
-                  <Font size="24.0" />
-               </font>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding><Insets left="10.0" right="10.0"/></padding>
+            <Label text="Lista de Variantes de Producto" styleClass="header-title">
+               <font><Font size="24.0"/></font>
             </Label>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+            <Label text="Producto ID:"/>
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
          </HBox>
          <Separator />
       </VBox>
@@ -33,26 +34,7 @@
             <Insets bottom="10.0" left="15.0" right="15.0" top="10.0"/>
          </padding>
 
-         <VBox>
-            <Label text="Filtros de Búsqueda">
-            </Label>
-            <HBox alignment="CENTER_LEFT" spacing="15.0">
-               <padding>
-                  <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
-               </padding>
-               <Label text="Producto ID:">
-               </Label>
-               <TextField fx:id="txt_Buscar" prefWidth="300.0" promptText="Buscar..."/>
-               <Button text="Buscar" onAction="#call_Buscar"/>
-               <Button fx:id="btn_Limpiar" onAction="#call_Limpiar" text="Limpiar"/>
-            </HBox>
-         </VBox>
-
          <VBox VBox.vgrow="ALWAYS">
-            <HBox alignment="CENTER_LEFT" spacing="10.0">
-               <Label text="Lista de Variantes">
-               </Label>
-            </HBox>
             <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>

--- a/src/proyectobd/VarianteProductoGui/Lst_VariantesProducto_GuiController.java
+++ b/src/proyectobd/VarianteProductoGui/Lst_VariantesProducto_GuiController.java
@@ -126,8 +126,4 @@ public class Lst_VariantesProducto_GuiController implements Initializable {
         }
     }
 
-    public void call_Limpiar(){
-        txt_Buscar.clear();
-        call_Buscar();
-    }
 }

--- a/src/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_Gui.fxml
+++ b/src/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_Gui.fxml
@@ -1,51 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VarianteProductoGui.Mnt_VariantesProducto_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VarianteProductoGui.Mnt_VariantesProducto_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="50.0" prefWidth="600.0" styleClass="header-section">
-            <children>
-                <Label layoutX="170.0" layoutY="12.0" text="Formulario de Mantenimiento de Variantes de Producto" styleClass="header-title">
-                    <font>
-                        <Font size="24.0" />
-                    </font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="250.0" prefWidth="600.0" text="Detalles" animated="false">
-            <content>
-                <AnchorPane prefHeight="230.0" prefWidth="598.0">
-                    <children>
-                        <Label layoutX="96.0" layoutY="36.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="150.0" layoutY="32.0" prefWidth="400.0" />
-                        <Label layoutX="48.0" layoutY="72.0" text="Producto:" />
-                        <ComboBox fx:id="cmb_producto" layoutX="150.0" layoutY="68.0" prefWidth="400.0" />
-                        <Label layoutX="102.0" layoutY="108.0" text="SKU:" />
-                        <TextField fx:id="txt_sku" layoutX="150.0" layoutY="104.0" prefWidth="400.0" />
-                        <Label layoutX="84.0" layoutY="144.0" text="Precio:" />
-                        <TextField fx:id="txt_precio" layoutX="150.0" layoutY="140.0" prefWidth="400.0" />
-                        <Label layoutX="92.0" layoutY="180.0" text="Stock:" />
-                        <TextField fx:id="txt_stock" layoutX="150.0" layoutY="176.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="289.0" prefHeight="61.0" prefWidth="600.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane>
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="440.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="509.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Variantes de Producto" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="80.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Producto:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_producto" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="SKU:" GridPane.rowIndex="2" />
+                  <TextField fx:id="txt_sku" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Precio:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_precio" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Stock:" GridPane.rowIndex="4" />
+                  <TextField fx:id="txt_stock" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>

--- a/src/proyectobd/VendedoresGui/Lst_Vendedores_Gui.fxml
+++ b/src/proyectobd/VendedoresGui/Lst_Vendedores_Gui.fxml
@@ -1,70 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
 
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TableColumn?>
-<?import javafx.scene.control.TableView?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
+<?import javafx.geometry.Insets?>
 
 <AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VendedoresGui.Lst_Vendedores_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
-      <Pane AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-         <children>
-            <Label layoutX="309.0" layoutY="3.0" text="Lista de Vendedores" styleClass="header-title">
+      <BorderPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+   <top>
+      <VBox>
+         <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
+            <padding>
+               <Insets left="10.0" right="10.0"/>
+            </padding>
+            <Label text="Lista de Vendedores" styleClass="header-title">
                <font>
-                  <Font name="Arial Black" size="24.0" />
+                  <Font size="24.0" />
                </font>
             </Label>
-         </children>
-      </Pane>
-      <TitledPane layoutY="39.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="39.0" prefHeight="87.0" prefWidth="800.0" text="Filtros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <Label layoutX="29.0" layoutY="22.0" text="Buscar:" />
-                  <TextField fx:id="txt_Buscar" layoutX="75.0" layoutY="18.0" prefHeight="25.0" prefWidth="624.0" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="126.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="126.0" AnchorPane.bottomAnchor="67.0" prefHeight="407.0" prefWidth="800.0" text="Registros" animated="false">
-        <content>
-          <AnchorPane prefHeight="180.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefWidth="200.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <TableView fx:id="tbl_Lista" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <columns>
-                      <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-                      <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
-                      <TableColumn fx:id="col_nombre" prefWidth="150.0" text="Tienda" />
-                      <TableColumn fx:id="col_calificacion" prefWidth="100.0" text="Calificación" />
-                    </columns>
-                    <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                    </columnResizePolicy>
-                  </TableView>
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
-      <TitledPane layoutY="533.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0" prefHeight="67.0" prefWidth="800.0" text="Acciones" animated="false">
-        <content>
-          <AnchorPane prefHeight="27.0" prefWidth="479.0" minHeight="0.0" minWidth="0.0">
-               <children>
-                  <Button fx:id="btn_Nuevo" layoutX="435.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_NuevoRegistro" text="Nuevo" />
-                  <Button fx:id="btn_Editar" layoutX="494.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Editar" text="Editar" />
-                  <Button fx:id="btn_Borrar" layoutX="552.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Borrar" text="Borrar" />
-                  <Button fx:id="btn_Cerrar" layoutX="611.0" layoutY="8.0" text="Cerrar" mnemonicParsing="false" onAction="#call_CerrarVentana" />
-               </children>
-            </AnchorPane>
-        </content>
-      </TitledPane>
+         </HBox>
+         <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Label text="Buscar:" />
+            <TextField fx:id="txt_Buscar" HBox.hgrow="ALWAYS" />
+         </HBox>
+         <Separator />
+      </VBox>
+   </top>
+   <center>
+      <VBox spacing="5.0">
+         <padding>
+            <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+         </padding>
+         <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
+            <columns>
+              <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
+              <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
+              <TableColumn fx:id="col_nombre" prefWidth="150.0" text="Tienda" />
+              <TableColumn fx:id="col_calificacion" prefWidth="100.0" text="Calificación" />
+            </columns>
+            <columnResizePolicy>
+               <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+            </columnResizePolicy>
+         </TableView>
+      </VBox>
+   </center>
+   <bottom>
+      <VBox>
+         <Separator />
+         <HBox alignment="CENTER_RIGHT" spacing="10.0">
+            <padding>
+               <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+            </padding>
+            <Region HBox.hgrow="ALWAYS" />
+            <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
+            <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
+            <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+         </HBox>
+      </VBox>
+   </bottom>
+      </BorderPane>
    </children>
 </AnchorPane>

--- a/src/proyectobd/VendedoresGui/Mnt_Vendedores_Gui.fxml
+++ b/src/proyectobd/VendedoresGui/Mnt_Vendedores_Gui.fxml
@@ -1,56 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
-
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.control.ComboBox?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" fx:id="Ap_Main" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VendedoresGui.Mnt_Vendedores_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.VendedoresGui.Mnt_Vendedores_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
-    <children>
-        <Pane prefHeight="39.0" prefWidth="800.0" styleClass="header-section">
-            <children>
-                <Label layoutX="220.0" layoutY="2.0" text="Mantenimiento de Vendedores" styleClass="header-title">
-                    <font>
-                        <Font name="Arial Black" size="24.0" />
-                    </font>
-                </Label>
-            </children>
-        </Pane>
-        <TitledPane layoutY="39.0" prefHeight="300.0" prefWidth="800.0" text="Detalles del Registro" animated="false">
-            <content>
-                <AnchorPane prefHeight="280.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Label layoutX="170.0" layoutY="40.0" text="ID:" />
-                        <TextField fx:id="txt_id" layoutX="220.0" layoutY="36.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="126.0" layoutY="76.0" text="Usuario ID:" />
-                        <ComboBox fx:id="cmb_usuario" layoutX="220.0" layoutY="72.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="102.0" layoutY="112.0" text="Nombre Tienda:" />
-                        <TextField fx:id="txt_nombre" layoutX="220.0" layoutY="108.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="136.0" layoutY="148.0" text="Descripción:" />
-                        <TextField fx:id="txt_descripcion" layoutX="220.0" layoutY="144.0" prefHeight="25.0" prefWidth="400.0" />
-                        <Label layoutX="131.0" layoutY="184.0" text="Calificación:" />
-                        <TextField fx:id="txt_calificacion" layoutX="220.0" layoutY="180.0" prefHeight="25.0" prefWidth="400.0" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-        <TitledPane layoutY="339.0" prefHeight="61.0" prefWidth="800.0" text="Acciones" animated="false">
-            <content>
-                <AnchorPane prefHeight="27.0" prefWidth="798.0" minHeight="0.0" minWidth="0.0">
-                    <children>
-                        <Button fx:id="btn_Grabar" layoutX="555.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_Grabar" text="Grabar" />
-                        <Button fx:id="btn_Cerrar" layoutX="624.0" layoutY="8.0" mnemonicParsing="false" onAction="#call_CerrarVentana" text="Cerrar" />
-                    </children>
-                </AnchorPane>
-            </content>
-        </TitledPane>
-    </children>
+   <children>
+      <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+         <top>
+            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+               <padding><Insets left="10.0" right="10.0"/></padding>
+               <Label text="Mantenimiento de Vendedores" styleClass="header-title">
+                  <font><Font size="18.0"/></font>
+               </Label>
+            </HBox>
+         </top>
+         <center>
+            <GridPane hgap="10.0" vgap="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <columnConstraints>
+                  <ColumnConstraints minWidth="120.0" />
+                  <ColumnConstraints hgrow="ALWAYS" />
+               </columnConstraints>
+               <children>
+                  <Label text="ID:" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <Label text="Usuario ID:" GridPane.rowIndex="1" />
+                  <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                  <Label text="Nombre Tienda:" GridPane.rowIndex="2" />
+                  <TextField fx:id="txt_nombre" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <Label text="Descripción:" GridPane.rowIndex="3" />
+                  <TextField fx:id="txt_descripcion" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <Label text="Calificación:" GridPane.rowIndex="4" />
+                  <TextField fx:id="txt_calificacion" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+               </children>
+            </GridPane>
+         </center>
+         <bottom>
+            <HBox alignment="CENTER_RIGHT" spacing="10.0">
+               <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
+               <Region HBox.hgrow="ALWAYS" />
+               <Button fx:id="btn_Grabar" onAction="#call_Grabar" text="Grabar" />
+               <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            </HBox>
+         </bottom>
+      </BorderPane>
+   </children>
 </AnchorPane>


### PR DESCRIPTION
## Summary
- refactor leftover list interfaces to match product layout
- remove titled panes in lists and switch to BorderPane

## Testing
- `ant -p` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682d6c58c4833297846b674341af9f