### PR TITLE
Fix category GUI imports and enhance vendor list

### DIFF
--- a/src/dao/CarritoDAO.java
+++ b/src/dao/CarritoDAO.java
@@ -30,7 +30,8 @@ public class CarritoDAO {
     public ObservableList<CarritoDTO> ListarCarritos(){
         ObservableList<CarritoDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, usuario_id, creado_en FROM carritos ORDER BY id";
+        String sql = "SELECT c.id, c.usuario_id, u.nombre AS usuario_nombre, c.creado_en " +
+                     "FROM carritos c JOIN usuarios u ON c.usuario_id=u.id ORDER BY c.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -38,6 +39,7 @@ public class CarritoDAO {
                 CarritoDTO dto = new CarritoDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setCreadoEn(rs.getTimestamp("creado_en"));
                 lista.add(dto);
             }
@@ -51,7 +53,10 @@ public class CarritoDAO {
     public ObservableList<CarritoDTO> BuscarCarritos(String criterio){
         ObservableList<CarritoDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, usuario_id, creado_en FROM carritos WHERE usuario_id LIKE '%"+criterio+"%' ORDER BY id";
+        String sql = "SELECT c.id, c.usuario_id, u.nombre AS usuario_nombre, c.creado_en " +
+                     "FROM carritos c JOIN usuarios u ON c.usuario_id=u.id " +
+                     "WHERE u.nombre LIKE '%"+criterio+"%' OR c.usuario_id LIKE '%"+criterio+"%' " +
+                     "ORDER BY c.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -59,6 +64,7 @@ public class CarritoDAO {
                 CarritoDTO dto = new CarritoDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setCreadoEn(rs.getTimestamp("creado_en"));
                 lista.add(dto);
             }

--- a/src/dao/CarritoItemDAO.java
+++ b/src/dao/CarritoItemDAO.java
@@ -46,7 +46,15 @@ public class CarritoItemDAO {
     public ObservableList<CarritoItemDTO> ListarItems(int carritoId){
         ObservableList<CarritoItemDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, carrito_id, variante_id, cantidad FROM carrito_items WHERE carrito_id="+carritoId+" ORDER BY id";
+        String sql = "SELECT ci.id, ci.carrito_id, ci.variante_id, v.sku AS variante_sku, " +
+                     "p.titulo AS producto_nombre, ci.cantidad " +
+                     "FROM carrito_items ci " +
+                     "JOIN variantes_producto v ON ci.variante_id=v.id " +
+                     "JOIN productos p ON v.producto_id=p.id ";
+        if(carritoId>0){
+            sql += "WHERE ci.carrito_id="+carritoId+" ";
+        }
+        sql += "ORDER BY ci.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -55,6 +63,8 @@ public class CarritoItemDAO {
                 dto.setId(rs.getInt("id"));
                 dto.setCarritoId(rs.getInt("carrito_id"));
                 dto.setVarianteId(rs.getInt("variante_id"));
+                dto.setVarianteSku(rs.getString("variante_sku"));
+                dto.setProductoNombre(rs.getString("producto_nombre"));
                 dto.setCantidad(rs.getInt("cantidad"));
                 lista.add(dto);
             }

--- a/src/dao/CategoriaDAO.java
+++ b/src/dao/CategoriaDAO.java
@@ -30,7 +30,8 @@ public class CategoriaDAO {
     public ObservableList<CategoriaDTO> ListarCategorias(){
         ObservableList<CategoriaDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, nombre, parent_id FROM categorias ORDER BY id";
+        String sql = "SELECT c.id, c.nombre, c.parent_id, p.nombre AS parent_nombre " +
+                     "FROM categorias c LEFT JOIN categorias p ON c.parent_id=p.id ORDER BY c.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -40,6 +41,7 @@ public class CategoriaDAO {
                 dto.setNombre(rs.getString("nombre"));
                 int pid = rs.getInt("parent_id");
                 if(rs.wasNull()) dto.setParentId(null); else dto.setParentId(pid);
+                dto.setParentNombre(rs.getString("parent_nombre"));
                 lista.add(dto);
             }
             ConnBD.CerrarConexionBD();
@@ -52,7 +54,9 @@ public class CategoriaDAO {
     public ObservableList<CategoriaDTO> BuscarCategorias(String criterio){
         ObservableList<CategoriaDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, nombre, parent_id FROM categorias WHERE nombre LIKE '%"+criterio+"%' ORDER BY id";
+        String sql = "SELECT c.id, c.nombre, c.parent_id, p.nombre AS parent_nombre " +
+                     "FROM categorias c LEFT JOIN categorias p ON c.parent_id=p.id " +
+                     "WHERE c.nombre LIKE '%"+criterio+"%' ORDER BY c.id"; 
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -62,6 +66,7 @@ public class CategoriaDAO {
                 dto.setNombre(rs.getString("nombre"));
                 int pid = rs.getInt("parent_id");
                 if(rs.wasNull()) dto.setParentId(null); else dto.setParentId(pid);
+                dto.setParentNombre(rs.getString("parent_nombre"));
                 lista.add(dto);
             }
             ConnBD.CerrarConexionBD();

--- a/src/dao/DireccionDAO.java
+++ b/src/dao/DireccionDAO.java
@@ -30,7 +30,9 @@ public class DireccionDAO {
     public ObservableList<DireccionDTO> ListarDirecciones(){
         ObservableList<DireccionDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT * FROM direcciones ORDER BY id";
+        String sql = "SELECT d.*, u.nombre AS usuario_nombre " +
+                     "FROM direcciones d JOIN usuarios u ON d.usuario_id=u.id " +
+                     "ORDER BY d.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -38,6 +40,7 @@ public class DireccionDAO {
                 DireccionDTO dto = new DireccionDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setAlias(rs.getString("alias"));
                 dto.setDireccion(rs.getString("direccion"));
                 dto.setCiudad(rs.getString("ciudad"));
@@ -56,7 +59,9 @@ public class DireccionDAO {
     public ObservableList<DireccionDTO> BuscarDirecciones(String criterio){
         ObservableList<DireccionDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT * FROM direcciones WHERE ciudad LIKE '%"+criterio+"%' ORDER BY id";
+        String sql = "SELECT d.*, u.nombre AS usuario_nombre " +
+                     "FROM direcciones d JOIN usuarios u ON d.usuario_id=u.id " +
+                     "WHERE d.ciudad LIKE '%"+criterio+"%' ORDER BY d.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -64,6 +69,7 @@ public class DireccionDAO {
                 DireccionDTO dto = new DireccionDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setAlias(rs.getString("alias"));
                 dto.setDireccion(rs.getString("direccion"));
                 dto.setCiudad(rs.getString("ciudad"));

--- a/src/dao/EnvioDAO.java
+++ b/src/dao/EnvioDAO.java
@@ -46,7 +46,10 @@ public class EnvioDAO {
     public ObservableList<EnvioDTO> ListarEnvios(){
         ObservableList<EnvioDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT * FROM envios ORDER BY id";
+        String sql = "SELECT e.id, e.orden_id, e.direccion_id, u.nombre AS usuario_nombre, d.nombre AS direccion_nombre, " +
+                     "e.empresa_envio, e.codigo_tracking, e.fecha_envio, e.fecha_entrega_estimada, e.fecha_entrega_real " +
+                     "FROM envios e JOIN ordenes o ON e.orden_id=o.id JOIN usuarios u ON o.usuario_id=u.id " +
+                     "JOIN direcciones d ON e.direccion_id=d.id ORDER BY e.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -55,6 +58,8 @@ public class EnvioDAO {
                 dto.setId(rs.getInt("id"));
                 dto.setOrdenId(rs.getInt("orden_id"));
                 dto.setDireccionId(rs.getInt("direccion_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
+                dto.setDireccionNombre(rs.getString("direccion_nombre"));
                 dto.setEmpresaEnvio(rs.getString("empresa_envio"));
                 dto.setCodigoTracking(rs.getString("codigo_tracking"));
                 dto.setFechaEnvio(rs.getTimestamp("fecha_envio"));

--- a/src/dao/ListaDeseoDAO.java
+++ b/src/dao/ListaDeseoDAO.java
@@ -30,7 +30,8 @@ public class ListaDeseoDAO {
     public ObservableList<ListaDeseoDTO> ListarListas(){
         ObservableList<ListaDeseoDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, usuario_id, nombre, creado_en FROM listas_deseos ORDER BY id";
+        String sql = "SELECT l.id, l.usuario_id, u.nombre AS usuario_nombre, l.nombre, l.creado_en " +
+                     "FROM listas_deseos l JOIN usuarios u ON l.usuario_id=u.id ORDER BY l.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -38,6 +39,7 @@ public class ListaDeseoDAO {
                 ListaDeseoDTO dto = new ListaDeseoDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setNombre(rs.getString("nombre"));
                 dto.setCreadoEn(rs.getTimestamp("creado_en"));
                 lista.add(dto);

--- a/src/dao/ListaDeseoItemDAO.java
+++ b/src/dao/ListaDeseoItemDAO.java
@@ -46,7 +46,15 @@ public class ListaDeseoItemDAO {
     public ObservableList<ListaDeseoItemDTO> ListarItems(int listaId){
         ObservableList<ListaDeseoItemDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, lista_deseos_id, variante_id, cantidad FROM lista_deseos_items WHERE lista_deseos_id="+listaId+" ORDER BY id";
+        String sql = "SELECT li.id, li.lista_deseos_id, li.variante_id, v.sku AS variante_sku, " +
+                     "p.titulo AS producto_nombre, li.cantidad " +
+                     "FROM lista_deseos_items li " +
+                     "JOIN variantes_producto v ON li.variante_id=v.id " +
+                     "JOIN productos p ON v.producto_id=p.id ";
+        if(listaId>0){
+            sql += "WHERE li.lista_deseos_id="+listaId+" ";
+        }
+        sql += "ORDER BY li.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -55,6 +63,8 @@ public class ListaDeseoItemDAO {
                 dto.setId(rs.getInt("id"));
                 dto.setListaDeseosId(rs.getInt("lista_deseos_id"));
                 dto.setVarianteId(rs.getInt("variante_id"));
+                dto.setVarianteSku(rs.getString("variante_sku"));
+                dto.setProductoNombre(rs.getString("producto_nombre"));
                 dto.setCantidad(rs.getInt("cantidad"));
                 lista.add(dto);
             }

--- a/src/dao/OrdenDAO.java
+++ b/src/dao/OrdenDAO.java
@@ -30,7 +30,8 @@ public class OrdenDAO {
     public ObservableList<OrdenDTO> ListarOrdenes(){
         ObservableList<OrdenDTO> ordenes = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, usuario_id, estado, total_bruto, total_descuento, fecha_creacion FROM ordenes ORDER BY id";
+        String sql = "SELECT o.id, o.usuario_id, u.nombre AS usuario_nombre, o.estado, o.total_bruto, o.total_descuento, o.fecha_creacion " +
+                     "FROM ordenes o JOIN usuarios u ON o.usuario_id=u.id ORDER BY o.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -38,6 +39,7 @@ public class OrdenDAO {
                 OrdenDTO dto = new OrdenDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setEstado(rs.getString("estado"));
                 dto.setTotalBruto(rs.getBigDecimal("total_bruto"));
                 dto.setTotalDescuento(rs.getBigDecimal("total_descuento"));
@@ -54,8 +56,9 @@ public class OrdenDAO {
     public ObservableList<OrdenDTO> BuscarOrdenes(String criterio){
         ObservableList<OrdenDTO> ordenes = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, usuario_id, estado, total_bruto, total_descuento, fecha_creacion FROM ordenes " +
-                     "WHERE estado LIKE '%"+criterio+"%' ORDER BY id";
+        String sql = "SELECT o.id, o.usuario_id, u.nombre AS usuario_nombre, o.estado, o.total_bruto, o.total_descuento, o.fecha_creacion " +
+                     "FROM ordenes o JOIN usuarios u ON o.usuario_id=u.id " +
+                     "WHERE o.estado LIKE '%"+criterio+"%' ORDER BY o.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -63,6 +66,7 @@ public class OrdenDAO {
                 OrdenDTO dto = new OrdenDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setEstado(rs.getString("estado"));
                 dto.setTotalBruto(rs.getBigDecimal("total_bruto"));
                 dto.setTotalDescuento(rs.getBigDecimal("total_descuento"));

--- a/src/dao/OrdenItemDAO.java
+++ b/src/dao/OrdenItemDAO.java
@@ -46,7 +46,10 @@ public class OrdenItemDAO {
     public ObservableList<OrdenItemDTO> ListarItems(int ordenId){
         ObservableList<OrdenItemDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, orden_id, variante_id, cantidad, precio_unitario, precio_descuento FROM orden_items WHERE orden_id="+ordenId+" ORDER BY id";
+        String sql = "SELECT oi.id, oi.orden_id, oi.variante_id, v.sku AS variante_sku, p.titulo AS producto_nombre, " +
+                     "oi.cantidad, oi.precio_unitario, oi.precio_descuento " +
+                     "FROM orden_items oi JOIN variantes_producto v ON oi.variante_id=v.id " +
+                     "JOIN productos p ON v.producto_id=p.id WHERE oi.orden_id="+ordenId+" ORDER BY oi.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -55,6 +58,8 @@ public class OrdenItemDAO {
                 dto.setId(rs.getInt("id"));
                 dto.setOrdenId(rs.getInt("orden_id"));
                 dto.setVarianteId(rs.getInt("variante_id"));
+                dto.setVarianteSku(rs.getString("variante_sku"));
+                dto.setProductoNombre(rs.getString("producto_nombre"));
                 dto.setCantidad(rs.getInt("cantidad"));
                 dto.setPrecioUnitario(rs.getDouble("precio_unitario"));
                 dto.setPrecioDescuento(rs.getDouble("precio_descuento"));

--- a/src/dao/PagoDAO.java
+++ b/src/dao/PagoDAO.java
@@ -30,7 +30,8 @@ public class PagoDAO {
     public ObservableList<PagoDTO> ListarPagos(){
         ObservableList<PagoDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, orden_id, metodo_pago, monto, fecha_pago FROM pagos ORDER BY id";
+        String sql = "SELECT p.id, p.orden_id, u.nombre AS usuario_nombre, p.metodo_pago, p.monto, p.fecha_pago " +
+                     "FROM pagos p JOIN ordenes o ON p.orden_id=o.id JOIN usuarios u ON o.usuario_id=u.id ORDER BY p.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -38,6 +39,7 @@ public class PagoDAO {
                 PagoDTO dto = new PagoDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setOrdenId(rs.getInt("orden_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setMetodoPago(rs.getString("metodo_pago"));
                 dto.setMonto(rs.getDouble("monto"));
                 dto.setFechaPago(rs.getTimestamp("fecha_pago"));

--- a/src/dao/ResenaDAO.java
+++ b/src/dao/ResenaDAO.java
@@ -46,7 +46,8 @@ public class ResenaDAO {
     public ObservableList<ResenaDTO> ListarResenas(){
         ObservableList<ResenaDTO> resenas = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, producto_id, usuario_id, rating, comentario, fecha FROM reseñas ORDER BY id";
+        String sql = "SELECT r.id, r.producto_id, p.titulo AS producto_nombre, r.usuario_id, u.nombre AS usuario_nombre, r.rating, r.comentario, r.fecha " +
+                     "FROM reseñas r JOIN productos p ON r.producto_id=p.id JOIN usuarios u ON r.usuario_id=u.id ORDER BY r.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -54,7 +55,9 @@ public class ResenaDAO {
                 ResenaDTO dto = new ResenaDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setProductoId(rs.getInt("producto_id"));
+                dto.setProductoNombre(rs.getString("producto_nombre"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setRating(rs.getInt("rating"));
                 dto.setComentario(rs.getString("comentario"));
                 dto.setFecha(rs.getTimestamp("fecha"));
@@ -70,8 +73,9 @@ public class ResenaDAO {
     public ObservableList<ResenaDTO> BuscarResenas(String criterio){
         ObservableList<ResenaDTO> resenas = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, producto_id, usuario_id, rating, comentario, fecha FROM reseñas " +
-                     "WHERE comentario LIKE '%"+criterio+"%' ORDER BY id";
+        String sql = "SELECT r.id, r.producto_id, p.titulo AS producto_nombre, r.usuario_id, u.nombre AS usuario_nombre, r.rating, r.comentario, r.fecha " +
+                     "FROM reseñas r JOIN productos p ON r.producto_id=p.id JOIN usuarios u ON r.usuario_id=u.id " +
+                     "WHERE r.comentario LIKE '%"+criterio+"%' ORDER BY r.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -79,7 +83,9 @@ public class ResenaDAO {
                 ResenaDTO dto = new ResenaDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setProductoId(rs.getInt("producto_id"));
+                dto.setProductoNombre(rs.getString("producto_nombre"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setRating(rs.getInt("rating"));
                 dto.setComentario(rs.getString("comentario"));
                 dto.setFecha(rs.getTimestamp("fecha"));

--- a/src/dao/UsuarioDAO.java
+++ b/src/dao/UsuarioDAO.java
@@ -133,6 +133,36 @@ public class UsuarioDAO {
         }
     }
 
+    // Obtiene un usuario por su ID
+    public UsuarioDTO ObtenerUsuarioPorId(int id){
+        ConectorBD ConnBD = new ConectorBD();
+        String sql = "SELECT u.id, u.rol_id, r.nombre AS rol_nombre, u.nombre, u.email, " +
+                     "u.contrase\u00f1a, u.imagen_perfil, u.creado_en " +
+                     "FROM usuarios u JOIN roles r ON u.rol_id=r.id WHERE u.id=?";
+        try{
+            PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
+            ps.setInt(1, id);
+            ResultSet rs = ps.executeQuery();
+            UsuarioDTO dto = null;
+            if(rs.next()){
+                dto = new UsuarioDTO();
+                dto.setId(rs.getInt("id"));
+                dto.setRolId(rs.getInt("rol_id"));
+                dto.setRolNombre(rs.getString("rol_nombre"));
+                dto.setNombre(rs.getString("nombre"));
+                dto.setEmail(rs.getString("email"));
+                dto.setContrasena(rs.getString("contrase\u00f1a"));
+                dto.setImagenPerfil(rs.getString("imagen_perfil"));
+                dto.setCreadoEn(rs.getTimestamp("creado_en"));
+            }
+            ConnBD.CerrarConexionBD();
+            return dto;
+        }catch(Exception ex){
+            fu.errorSQL(ex, "obtener usuario");
+            return null;
+        }
+    }
+
     public int EliminarUsuario(int id){
         try{
             String sql = "DELETE FROM usuarios WHERE id=?";

--- a/src/dao/VarianteProductoDAO.java
+++ b/src/dao/VarianteProductoDAO.java
@@ -30,7 +30,8 @@ public class VarianteProductoDAO {
     public ObservableList<VarianteProductoDTO> ListarVariantes(){
         ObservableList<VarianteProductoDTO> lista = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, producto_id, sku, precio, stock FROM variantes_producto ORDER BY id";
+        String sql = "SELECT v.id, v.producto_id, v.sku, p.titulo AS producto_nombre, v.precio, v.stock " +
+                     "FROM variantes_producto v JOIN productos p ON v.producto_id=p.id ORDER BY v.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -39,6 +40,7 @@ public class VarianteProductoDAO {
                 dto.setId(rs.getInt("id"));
                 dto.setProductoId(rs.getInt("producto_id"));
                 dto.setSku(rs.getString("sku"));
+                dto.setProductoNombre(rs.getString("producto_nombre"));
                 dto.setPrecio(rs.getDouble("precio"));
                 dto.setStock(rs.getInt("stock"));
                 lista.add(dto);

--- a/src/dao/VendedorDAO.java
+++ b/src/dao/VendedorDAO.java
@@ -30,7 +30,9 @@ public class VendedorDAO {
     public ObservableList<VendedorDTO> ListarVendedores(){
         ObservableList<VendedorDTO> vendedores = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, usuario_id, nombre_tienda, descripcion, calificacion_promedio FROM vendedores ORDER BY id";
+        String sql = "SELECT v.id, v.usuario_id, u.nombre AS usuario_nombre, " +
+                     "v.nombre_tienda, v.descripcion, v.calificacion_promedio " +
+                     "FROM vendedores v JOIN usuarios u ON v.usuario_id=u.id ORDER BY v.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -38,6 +40,7 @@ public class VendedorDAO {
                 VendedorDTO dto = new VendedorDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setNombreTienda(rs.getString("nombre_tienda"));
                 dto.setDescripcion(rs.getString("descripcion"));
                 dto.setCalificacionPromedio(rs.getBigDecimal("calificacion_promedio"));
@@ -53,8 +56,10 @@ public class VendedorDAO {
     public ObservableList<VendedorDTO> BuscarVendedores(String criterio){
         ObservableList<VendedorDTO> vendedores = FXCollections.observableArrayList();
         ConectorBD ConnBD = new ConectorBD();
-        String sql = "SELECT id, usuario_id, nombre_tienda, descripcion, calificacion_promedio FROM vendedores " +
-                     "WHERE nombre_tienda LIKE '%"+criterio+"%' ORDER BY id";
+        String sql = "SELECT v.id, v.usuario_id, u.nombre AS usuario_nombre, " +
+                     "v.nombre_tienda, v.descripcion, v.calificacion_promedio " +
+                     "FROM vendedores v JOIN usuarios u ON v.usuario_id=u.id " +
+                     "WHERE v.nombre_tienda LIKE '%"+criterio+"%' ORDER BY v.id";
         try{
             Statement st = ConnBD.AbrirConexionBD().createStatement();
             ResultSet rs = st.executeQuery(sql);
@@ -62,6 +67,7 @@ public class VendedorDAO {
                 VendedorDTO dto = new VendedorDTO();
                 dto.setId(rs.getInt("id"));
                 dto.setUsuarioId(rs.getInt("usuario_id"));
+                dto.setUsuarioNombre(rs.getString("usuario_nombre"));
                 dto.setNombreTienda(rs.getString("nombre_tienda"));
                 dto.setDescripcion(rs.getString("descripcion"));
                 dto.setCalificacionPromedio(rs.getBigDecimal("calificacion_promedio"));

--- a/src/dto/CarritoDTO.java
+++ b/src/dto/CarritoDTO.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 public class CarritoDTO {
     private int id;
     private int usuarioId;
+    private String usuarioNombre;
     private Timestamp creadoEn;
 
     public int getId() { return id; }
@@ -12,6 +13,9 @@ public class CarritoDTO {
 
     public int getUsuarioId() { return usuarioId; }
     public void setUsuarioId(int usuarioId) { this.usuarioId = usuarioId; }
+
+    public String getUsuarioNombre() { return usuarioNombre; }
+    public void setUsuarioNombre(String usuarioNombre) { this.usuarioNombre = usuarioNombre; }
 
     public Timestamp getCreadoEn() { return creadoEn; }
     public void setCreadoEn(Timestamp creadoEn) { this.creadoEn = creadoEn; }

--- a/src/dto/CarritoItemDTO.java
+++ b/src/dto/CarritoItemDTO.java
@@ -4,6 +4,8 @@ public class CarritoItemDTO {
     private int id;
     private int carritoId;
     private int varianteId;
+    private String varianteSku;
+    private String productoNombre;
     private int cantidad;
 
     public int getId() { return id; }
@@ -14,6 +16,12 @@ public class CarritoItemDTO {
 
     public int getVarianteId() { return varianteId; }
     public void setVarianteId(int varianteId) { this.varianteId = varianteId; }
+
+    public String getVarianteSku() { return varianteSku; }
+    public void setVarianteSku(String varianteSku) { this.varianteSku = varianteSku; }
+
+    public String getProductoNombre() { return productoNombre; }
+    public void setProductoNombre(String productoNombre) { this.productoNombre = productoNombre; }
 
     public int getCantidad() { return cantidad; }
     public void setCantidad(int cantidad) { this.cantidad = cantidad; }

--- a/src/dto/CategoriaDTO.java
+++ b/src/dto/CategoriaDTO.java
@@ -4,6 +4,7 @@ public class CategoriaDTO {
     private int id;
     private String nombre;
     private Integer parentId;
+    private String parentNombre;
 
     public int getId(){ return id; }
     public void setId(int id){ this.id = id; }
@@ -13,6 +14,9 @@ public class CategoriaDTO {
 
     public Integer getParentId(){ return parentId; }
     public void setParentId(Integer parentId){ this.parentId = parentId; }
+
+    public String getParentNombre() { return parentNombre; }
+    public void setParentNombre(String parentNombre) { this.parentNombre = parentNombre; }
 
     @Override
     public String toString() { return nombre; }

--- a/src/dto/DireccionDTO.java
+++ b/src/dto/DireccionDTO.java
@@ -3,6 +3,7 @@ package dto;
 public class DireccionDTO {
     private int id;
     private int usuarioId;
+    private String usuarioNombre;
     private String alias;
     private String direccion;
     private String ciudad;
@@ -15,6 +16,9 @@ public class DireccionDTO {
 
     public int getUsuarioId() { return usuarioId; }
     public void setUsuarioId(int usuarioId) { this.usuarioId = usuarioId; }
+
+    public String getUsuarioNombre() { return usuarioNombre; }
+    public void setUsuarioNombre(String usuarioNombre) { this.usuarioNombre = usuarioNombre; }
 
     public String getAlias() { return alias; }
     public void setAlias(String alias) { this.alias = alias; }

--- a/src/dto/EnvioDTO.java
+++ b/src/dto/EnvioDTO.java
@@ -6,6 +6,8 @@ public class EnvioDTO {
     private int id;
     private int ordenId;
     private int direccionId;
+    private String usuarioNombre;
+    private String direccionNombre;
     private String empresaEnvio;
     private String codigoTracking;
     private Timestamp fechaEnvio;
@@ -20,6 +22,12 @@ public class EnvioDTO {
 
     public int getDireccionId() { return direccionId; }
     public void setDireccionId(int direccionId) { this.direccionId = direccionId; }
+
+    public String getUsuarioNombre() { return usuarioNombre; }
+    public void setUsuarioNombre(String usuarioNombre) { this.usuarioNombre = usuarioNombre; }
+
+    public String getDireccionNombre() { return direccionNombre; }
+    public void setDireccionNombre(String direccionNombre) { this.direccionNombre = direccionNombre; }
 
     public String getEmpresaEnvio() { return empresaEnvio; }
     public void setEmpresaEnvio(String empresaEnvio) { this.empresaEnvio = empresaEnvio; }

--- a/src/dto/ListaDeseoDTO.java
+++ b/src/dto/ListaDeseoDTO.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 public class ListaDeseoDTO {
     private int id;
     private int usuarioId;
+    private String usuarioNombre;
     private String nombre;
     private Timestamp creadoEn;
 
@@ -13,6 +14,9 @@ public class ListaDeseoDTO {
 
     public int getUsuarioId() { return usuarioId; }
     public void setUsuarioId(int usuarioId) { this.usuarioId = usuarioId; }
+
+    public String getUsuarioNombre() { return usuarioNombre; }
+    public void setUsuarioNombre(String usuarioNombre) { this.usuarioNombre = usuarioNombre; }
 
     public String getNombre() { return nombre; }
     public void setNombre(String nombre) { this.nombre = nombre; }

--- a/src/dto/ListaDeseoItemDTO.java
+++ b/src/dto/ListaDeseoItemDTO.java
@@ -4,6 +4,8 @@ public class ListaDeseoItemDTO {
     private int id;
     private int listaDeseosId;
     private int varianteId;
+    private String varianteSku;
+    private String productoNombre;
     private int cantidad;
 
     public int getId() { return id; }
@@ -14,6 +16,12 @@ public class ListaDeseoItemDTO {
 
     public int getVarianteId() { return varianteId; }
     public void setVarianteId(int varianteId) { this.varianteId = varianteId; }
+
+    public String getVarianteSku() { return varianteSku; }
+    public void setVarianteSku(String varianteSku) { this.varianteSku = varianteSku; }
+
+    public String getProductoNombre() { return productoNombre; }
+    public void setProductoNombre(String productoNombre) { this.productoNombre = productoNombre; }
 
     public int getCantidad() { return cantidad; }
     public void setCantidad(int cantidad) { this.cantidad = cantidad; }

--- a/src/dto/OrdenDTO.java
+++ b/src/dto/OrdenDTO.java
@@ -6,6 +6,7 @@ import java.sql.Timestamp;
 public class OrdenDTO {
     private int id;
     private int usuarioId;
+    private String usuarioNombre;
     private String estado;
     private BigDecimal totalBruto;
     private BigDecimal totalDescuento;
@@ -25,6 +26,14 @@ public class OrdenDTO {
 
     public void setUsuarioId(int usuarioId) {
         this.usuarioId = usuarioId;
+    }
+
+    public String getUsuarioNombre() {
+        return usuarioNombre;
+    }
+
+    public void setUsuarioNombre(String usuarioNombre) {
+        this.usuarioNombre = usuarioNombre;
     }
 
     public String getEstado() {

--- a/src/dto/OrdenItemDTO.java
+++ b/src/dto/OrdenItemDTO.java
@@ -4,6 +4,8 @@ public class OrdenItemDTO {
     private int id;
     private int ordenId;
     private int varianteId;
+    private String varianteSku;
+    private String productoNombre;
     private int cantidad;
     private double precioUnitario;
     private double precioDescuento;
@@ -16,6 +18,12 @@ public class OrdenItemDTO {
 
     public int getVarianteId() { return varianteId; }
     public void setVarianteId(int varianteId) { this.varianteId = varianteId; }
+
+    public String getVarianteSku() { return varianteSku; }
+    public void setVarianteSku(String varianteSku) { this.varianteSku = varianteSku; }
+
+    public String getProductoNombre() { return productoNombre; }
+    public void setProductoNombre(String productoNombre) { this.productoNombre = productoNombre; }
 
     public int getCantidad() { return cantidad; }
     public void setCantidad(int cantidad) { this.cantidad = cantidad; }

--- a/src/dto/PagoDTO.java
+++ b/src/dto/PagoDTO.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 public class PagoDTO {
     private int id;
     private int ordenId;
+    private String usuarioNombre;
     private String metodoPago;
     private double monto;
     private Timestamp fechaPago;
@@ -14,6 +15,9 @@ public class PagoDTO {
 
     public int getOrdenId() { return ordenId; }
     public void setOrdenId(int ordenId) { this.ordenId = ordenId; }
+
+    public String getUsuarioNombre() { return usuarioNombre; }
+    public void setUsuarioNombre(String usuarioNombre) { this.usuarioNombre = usuarioNombre; }
 
     public String getMetodoPago() { return metodoPago; }
     public void setMetodoPago(String metodoPago) { this.metodoPago = metodoPago; }

--- a/src/dto/ResenaDTO.java
+++ b/src/dto/ResenaDTO.java
@@ -6,6 +6,8 @@ public class ResenaDTO {
     private int id;
     private int productoId;
     private int usuarioId;
+    private String usuarioNombre;
+    private String productoNombre;
     private int rating;
     private String comentario;
     private Timestamp fecha;
@@ -32,6 +34,22 @@ public class ResenaDTO {
 
     public void setUsuarioId(int usuarioId) {
         this.usuarioId = usuarioId;
+    }
+
+    public String getUsuarioNombre() {
+        return usuarioNombre;
+    }
+
+    public void setUsuarioNombre(String usuarioNombre) {
+        this.usuarioNombre = usuarioNombre;
+    }
+
+    public String getProductoNombre() {
+        return productoNombre;
+    }
+
+    public void setProductoNombre(String productoNombre) {
+        this.productoNombre = productoNombre;
     }
 
     public int getRating() {

--- a/src/dto/VarianteProductoDTO.java
+++ b/src/dto/VarianteProductoDTO.java
@@ -4,6 +4,7 @@ public class VarianteProductoDTO {
     private int id;
     private int productoId;
     private String sku;
+    private String productoNombre;
     private double precio;
     private int stock;
 
@@ -16,6 +17,9 @@ public class VarianteProductoDTO {
     public String getSku() { return sku; }
     public void setSku(String sku) { this.sku = sku; }
 
+    public String getProductoNombre() { return productoNombre; }
+    public void setProductoNombre(String productoNombre) { this.productoNombre = productoNombre; }
+
     public double getPrecio() { return precio; }
     public void setPrecio(double precio) { this.precio = precio; }
 
@@ -23,5 +27,5 @@ public class VarianteProductoDTO {
     public void setStock(int stock) { this.stock = stock; }
 
     @Override
-    public String toString() { return sku; }
+    public String toString() { return sku + " - " + (productoNombre != null ? productoNombre : ""); }
 }

--- a/src/dto/VendedorDTO.java
+++ b/src/dto/VendedorDTO.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 public class VendedorDTO {
     private int id;
     private int usuarioId;
+    private String usuarioNombre;
     private String nombreTienda;
     private String descripcion;
     private BigDecimal calificacionPromedio;
@@ -23,6 +24,14 @@ public class VendedorDTO {
 
     public void setUsuarioId(int usuarioId) {
         this.usuarioId = usuarioId;
+    }
+
+    public String getUsuarioNombre() {
+        return usuarioNombre;
+    }
+
+    public void setUsuarioNombre(String usuarioNombre) {
+        this.usuarioNombre = usuarioNombre;
     }
 
     public String getNombreTienda() {

--- a/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_Gui.fxml
+++ b/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_Gui.fxml
@@ -34,7 +34,7 @@
                   <columns>
                      <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>
                      <TableColumn fx:id="col_carrito" prefWidth="75.0" text="Carrito"/>
-                     <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante"/>
+                     <TableColumn fx:id="col_variante" prefWidth="250.0" text="Variante"/>
                      <TableColumn fx:id="col_cantidad" prefWidth="75.0" text="Cantidad"/>
                   </columns>
                   <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>

--- a/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_GuiController.java
+++ b/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_GuiController.java
@@ -27,7 +27,7 @@ public class Lst_CarritoItems_GuiController implements Initializable {
     @FXML private TableView<CarritoItemDTO> tbl_Lista;
     @FXML private TableColumn<CarritoItemDTO, Integer> col_id;
     @FXML private TableColumn<CarritoItemDTO, Integer> col_carrito;
-    @FXML private TableColumn<CarritoItemDTO, Integer> col_variante;
+    @FXML private TableColumn<CarritoItemDTO, String> col_variante;
     @FXML private TableColumn<CarritoItemDTO, Integer> col_cantidad;
 
     FeedbackCarritoItem fu = new FeedbackCarritoItem();
@@ -48,9 +48,16 @@ public class Lst_CarritoItems_GuiController implements Initializable {
             ObservableList<CarritoItemDTO> lista = dao.ListarItems(idCarrito);
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
             col_carrito.setCellValueFactory(new PropertyValueFactory<>("carritoId"));
-            col_variante.setCellValueFactory(new PropertyValueFactory<>("varianteId"));
+            col_variante.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getVarianteSku() + " - " + data.getValue().getProductoNombre() +
+                        " (" + data.getValue().getVarianteId() + ")"));
             col_cantidad.setCellValueFactory(new PropertyValueFactory<>("cantidad"));
             tbl_Lista.setItems(lista);
+            col_variante.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getVarianteSku() + " - " + data.getValue().getProductoNombre() +
+                        " (" + data.getValue().getVarianteId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_GuiController.java
+++ b/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_GuiController.java
@@ -35,6 +35,7 @@ public class Lst_CarritoItems_GuiController implements Initializable {
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         txt_Buscar.textProperty().addListener((obs, oldV, newV) -> { call_Buscar(); });
+        call_Buscar();
     }
 
     public void call_CerrarVentana(){

--- a/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_GuiController.java
+++ b/src/proyectobd/CarritoItemsGui/Lst_CarritoItems_GuiController.java
@@ -54,10 +54,6 @@ public class Lst_CarritoItems_GuiController implements Initializable {
                         " (" + data.getValue().getVarianteId() + ")"));
             col_cantidad.setCellValueFactory(new PropertyValueFactory<>("cantidad"));
             tbl_Lista.setItems(lista);
-            col_variante.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getVarianteSku() + " - " + data.getValue().getProductoNombre() +
-                        " (" + data.getValue().getVarianteId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_Gui.fxml
+++ b/src/proyectobd/CarritoItemsGui/Mnt_CarritoItems_Gui.fxml
@@ -28,7 +28,7 @@
                     </columnConstraints>
                     <children>
                         <Label text="ID:"/>
-                        <TextField fx:id="txt_id" GridPane.columnIndex="1"/>
+                        <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                         <Label text="Carrito:" GridPane.rowIndex="1"/>
                         <ComboBox fx:id="cmb_carrito" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
                         <Label text="Variante:" GridPane.rowIndex="2"/>

--- a/src/proyectobd/CarritosGui/Lst_Carritos_Gui.fxml
+++ b/src/proyectobd/CarritosGui/Lst_Carritos_Gui.fxml
@@ -33,7 +33,7 @@
                <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                   <columns>
                      <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
-                     <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario"/>
+                     <TableColumn fx:id="col_usuario" prefWidth="200.0" text="Usuario"/>
                      <TableColumn fx:id="col_creado" prefWidth="150.0" text="Creado"/>
                   </columns>
                   <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>

--- a/src/proyectobd/CarritosGui/Lst_Carritos_GuiController.java
+++ b/src/proyectobd/CarritosGui/Lst_Carritos_GuiController.java
@@ -26,7 +26,7 @@ public class Lst_Carritos_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<CarritoDTO> tbl_Lista;
     @FXML private TableColumn<CarritoDTO, Integer> col_id;
-    @FXML private TableColumn<CarritoDTO, Integer> col_usuario;
+    @FXML private TableColumn<CarritoDTO, String> col_usuario;
     @FXML private TableColumn<CarritoDTO, String> col_creado;
 
     FeedbackCarrito fu = new FeedbackCarrito();
@@ -47,9 +47,14 @@ public class Lst_Carritos_GuiController implements Initializable {
             CarritoDAO dao = new CarritoDAO();
             ObservableList<CarritoDTO> lista = dao.ListarCarritos();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_usuario.setCellValueFactory(new PropertyValueFactory<>("usuarioId"));
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
             col_creado.setCellValueFactory(new PropertyValueFactory<>("creadoEn"));
             tbl_Lista.setItems(lista);
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/CarritosGui/Lst_Carritos_GuiController.java
+++ b/src/proyectobd/CarritosGui/Lst_Carritos_GuiController.java
@@ -52,9 +52,6 @@ public class Lst_Carritos_GuiController implements Initializable {
                         data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
             col_creado.setCellValueFactory(new PropertyValueFactory<>("creadoEn"));
             tbl_Lista.setItems(lista);
-            col_usuario.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/CategoriasGui/Lst_Categorias_GuiController.java
+++ b/src/proyectobd/CategoriasGui/Lst_Categorias_GuiController.java
@@ -27,7 +27,7 @@ public class Lst_Categorias_GuiController implements Initializable {
     @FXML private TableView<CategoriaDTO> tbl_Lista;
     @FXML private TableColumn<CategoriaDTO, Integer> col_id;
     @FXML private TableColumn<CategoriaDTO, String> col_nombre;
-    @FXML private TableColumn<CategoriaDTO, Integer> col_parent;
+    @FXML private TableColumn<CategoriaDTO, String> col_parent;
 
     FeedbackCategoria fu = new FeedbackCategoria();
 
@@ -48,7 +48,10 @@ public class Lst_Categorias_GuiController implements Initializable {
             ObservableList<CategoriaDTO> lista = dao.ListarCategorias();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
             col_nombre.setCellValueFactory(new PropertyValueFactory<>("nombre"));
-            col_parent.setCellValueFactory(new PropertyValueFactory<>("parentId"));
+            col_parent.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getParentNombre() == null ? "" :
+                        data.getValue().getParentNombre() + " (" + data.getValue().getParentId() + ")"));
             tbl_Lista.setItems(lista);
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());

--- a/src/proyectobd/CategoriasGui/Mnt_Categorias_Gui.fxml
+++ b/src/proyectobd/CategoriasGui/Mnt_Categorias_Gui.fxml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import java.net.URL?>
 
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.ComboBox?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
 <AnchorPane styleClass="main-pane" prefHeight="300.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CategoriasGui.Mnt_Categorias_GuiController">

--- a/src/proyectobd/CategoriasGui/Mnt_Categorias_Gui.fxml
+++ b/src/proyectobd/CategoriasGui/Mnt_Categorias_Gui.fxml
@@ -3,6 +3,7 @@
 
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.text.Font?>
 
 <AnchorPane styleClass="main-pane" prefHeight="300.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.CategoriasGui.Mnt_Categorias_GuiController">

--- a/src/proyectobd/CategoriasGui/Mnt_Categorias_Gui.fxml
+++ b/src/proyectobd/CategoriasGui/Mnt_Categorias_Gui.fxml
@@ -28,7 +28,7 @@
                </columnConstraints>
                <children>
                   <Label text="ID:"/>
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1"/>
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Nombre:" GridPane.rowIndex="1"/>
                   <TextField fx:id="txt_nombre" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
                   <Label text="Padre:" GridPane.rowIndex="2"/>

--- a/src/proyectobd/DireccionesGui/Lst_Direcciones_Gui.fxml
+++ b/src/proyectobd/DireccionesGui/Lst_Direcciones_Gui.fxml
@@ -33,7 +33,7 @@
                <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                   <columns>
                      <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>
-                     <TableColumn fx:id="col_usuario" prefWidth="50.0" text="Usr"/>
+                     <TableColumn fx:id="col_usuario" prefWidth="150.0" text="Usuario"/>
                      <TableColumn fx:id="col_ciudad" prefWidth="100.0" text="Ciudad"/>
                      <TableColumn fx:id="col_provincia" prefWidth="100.0" text="Provincia"/>
                   </columns>

--- a/src/proyectobd/DireccionesGui/Lst_Direcciones_GuiController.java
+++ b/src/proyectobd/DireccionesGui/Lst_Direcciones_GuiController.java
@@ -26,7 +26,7 @@ public class Lst_Direcciones_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<DireccionDTO> tbl_Lista;
     @FXML private TableColumn<DireccionDTO, Integer> col_id;
-    @FXML private TableColumn<DireccionDTO, Integer> col_usuario;
+    @FXML private TableColumn<DireccionDTO, String> col_usuario;
     @FXML private TableColumn<DireccionDTO, String> col_ciudad;
     @FXML private TableColumn<DireccionDTO, String> col_provincia;
 
@@ -48,7 +48,9 @@ public class Lst_Direcciones_GuiController implements Initializable {
             DireccionDAO dao = new DireccionDAO();
             ObservableList<DireccionDTO> lista = dao.ListarDirecciones();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_usuario.setCellValueFactory(new PropertyValueFactory<>("usuarioId"));
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
             col_ciudad.setCellValueFactory(new PropertyValueFactory<>("ciudad"));
             col_provincia.setCellValueFactory(new PropertyValueFactory<>("provincia"));
             tbl_Lista.setItems(lista);
@@ -72,6 +74,9 @@ public class Lst_Direcciones_GuiController implements Initializable {
                 }
             }
             tbl_Lista.setItems(lista);
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/DireccionesGui/Lst_Direcciones_GuiController.java
+++ b/src/proyectobd/DireccionesGui/Lst_Direcciones_GuiController.java
@@ -74,9 +74,6 @@ public class Lst_Direcciones_GuiController implements Initializable {
                 }
             }
             tbl_Lista.setItems(lista);
-            col_usuario.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/DireccionesGui/Mnt_Direcciones_Gui.fxml
+++ b/src/proyectobd/DireccionesGui/Mnt_Direcciones_Gui.fxml
@@ -34,9 +34,9 @@
                   <Label text="Dirección:" GridPane.rowIndex="2" />
                   <TextField fx:id="txt_direccion" GridPane.columnIndex="1" GridPane.rowIndex="2" />
                   <Label text="Ciudad:" GridPane.rowIndex="3" />
-                  <TextField fx:id="txt_ciudad" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <ComboBox fx:id="cmb_ciudad" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                   <Label text="Provincia:" GridPane.rowIndex="4" />
-                  <TextField fx:id="txt_provincia" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                  <ComboBox fx:id="cmb_provincia" GridPane.columnIndex="1" GridPane.rowIndex="4" />
                   <Label text="Código Postal:" GridPane.rowIndex="5" />
                   <TextField fx:id="txt_postal" GridPane.columnIndex="1" GridPane.rowIndex="5" />
                   <Label text="Teléfono:" GridPane.rowIndex="6" />

--- a/src/proyectobd/DireccionesGui/Mnt_Direcciones_GuiController.java
+++ b/src/proyectobd/DireccionesGui/Mnt_Direcciones_GuiController.java
@@ -29,8 +29,8 @@ public class Mnt_Direcciones_GuiController implements Initializable {
     @FXML private ComboBox<UsuarioDTO> cmb_usuario;
     @FXML private TextField txt_alias;
     @FXML private TextField txt_direccion;
-    @FXML private TextField txt_ciudad;
-    @FXML private TextField txt_provincia;
+    @FXML private ComboBox<String> cmb_ciudad;
+    @FXML private ComboBox<String> cmb_provincia;
     @FXML private TextField txt_postal;
     @FXML private TextField txt_telefono;
 
@@ -51,8 +51,8 @@ public class Mnt_Direcciones_GuiController implements Initializable {
                 dto.setUsuarioId(cmb_usuario.getValue().getId());
                 dto.setAlias(txt_alias.getText());
                 dto.setDireccion(txt_direccion.getText());
-                dto.setCiudad(txt_ciudad.getText());
-                dto.setProvincia(txt_provincia.getText());
+                dto.setCiudad(cmb_ciudad.getValue());
+                dto.setProvincia(cmb_provincia.getValue());
                 dto.setCodigoPostal(txt_postal.getText());
                 dto.setTelefonoContacto(txt_telefono.getText());
                 int id = dao.InsertarDireccion(dto);
@@ -68,8 +68,8 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             dto.setUsuarioId(cmb_usuario.getValue().getId());
             dto.setAlias(txt_alias.getText());
             dto.setDireccion(txt_direccion.getText());
-            dto.setCiudad(txt_ciudad.getText());
-            dto.setProvincia(txt_provincia.getText());
+            dto.setCiudad(cmb_ciudad.getValue());
+            dto.setProvincia(cmb_provincia.getValue());
             dto.setCodigoPostal(txt_postal.getText());
             dto.setTelefonoContacto(txt_telefono.getText());
             try{
@@ -97,14 +97,14 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             txt_direccion.requestFocus();
             return false;
         }
-        if(txt_ciudad.getText().trim().isEmpty()){
-            fu.datosInvalidos("Ciudad: ingrese un texto.");
-            txt_ciudad.requestFocus();
+        if(cmb_ciudad.getValue() == null){
+            fu.datosInvalidos("Ciudad: seleccione un valor.");
+            cmb_ciudad.requestFocus();
             return false;
         }
-        if(txt_provincia.getText().trim().isEmpty()){
-            fu.datosInvalidos("Provincia: ingrese un texto.");
-            txt_provincia.requestFocus();
+        if(cmb_provincia.getValue() == null){
+            fu.datosInvalidos("Provincia: seleccione un valor.");
+            cmb_provincia.requestFocus();
             return false;
         }
         if(txt_postal.getText().trim().isEmpty()){
@@ -125,8 +125,8 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             }
             txt_alias.setText(dto.getAlias());
             txt_direccion.setText(dto.getDireccion());
-            txt_ciudad.setText(dto.getCiudad());
-            txt_provincia.setText(dto.getProvincia());
+            cmb_ciudad.setValue(dto.getCiudad());
+            cmb_provincia.setValue(dto.getProvincia());
             txt_postal.setText(dto.getCodigoPostal());
             txt_telefono.setText(dto.getTelefonoContacto());
         }
@@ -138,6 +138,21 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             UsuarioDAO udao = new UsuarioDAO();
             usuarios.addAll(udao.ListarUsuarios());
             cmb_usuario.setItems(usuarios);
+
+            ObservableList<String> provincias = FXCollections.observableArrayList(
+                    "Azuay", "Bolívar", "Cañar", "Carchi", "Chimborazo",
+                    "Cotopaxi", "El Oro", "Esmeraldas", "Galápagos", "Guayas",
+                    "Imbabura", "Loja", "Los Ríos", "Manabí", "Morona Santiago",
+                    "Napo", "Orellana", "Pastaza", "Pichincha", "Santa Elena",
+                    "Santo Domingo", "Sucumbíos", "Tungurahua", "Zamora Chinchipe"
+            );
+            cmb_provincia.setItems(provincias);
+
+            ObservableList<String> ciudades = FXCollections.observableArrayList(
+                    "Quito", "Guayaquil", "Cuenca", "Ambato", "Manta",
+                    "Portoviejo", "Loja", "Machala", "Esmeraldas", "Santo Domingo"
+            );
+            cmb_ciudad.setItems(ciudades);
         } catch (Exception ex) {
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
+++ b/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
@@ -27,8 +27,8 @@ public class Lst_Envios_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<EnvioDTO> tbl_Lista;
     @FXML private TableColumn<EnvioDTO, Integer> col_id;
-    @FXML private TableColumn<EnvioDTO, Integer> col_orden;
-    @FXML private TableColumn<EnvioDTO, Integer> col_direccion;
+    @FXML private TableColumn<EnvioDTO, String> col_orden;
+    @FXML private TableColumn<EnvioDTO, String> col_direccion;
     @FXML private TableColumn<EnvioDTO, String> col_empresa;
     @FXML private TableColumn<EnvioDTO, String> col_tracking;
     @FXML private TableColumn<EnvioDTO, Timestamp> col_envio;
@@ -56,8 +56,8 @@ public class Lst_Envios_GuiController implements Initializable {
                 lista.removeIf(e -> e.getOrdenId() != ordenId);
             }
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_orden.setCellValueFactory(new PropertyValueFactory<>("ordenId"));
-            col_direccion.setCellValueFactory(new PropertyValueFactory<>("direccionId"));
+            col_orden.setCellValueFactory(new PropertyValueFactory<>("usuarioNombre"));
+            col_direccion.setCellValueFactory(new PropertyValueFactory<>("direccionNombre"));
             col_empresa.setCellValueFactory(new PropertyValueFactory<>("empresaEnvio"));
             col_tracking.setCellValueFactory(new PropertyValueFactory<>("codigoTracking"));
             col_envio.setCellValueFactory(new PropertyValueFactory<>("fechaEnvio"));

--- a/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
+++ b/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
@@ -16,6 +16,7 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import java.sql.Timestamp;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackEnvio;
 
@@ -56,14 +57,24 @@ public class Lst_Envios_GuiController implements Initializable {
                 lista.removeIf(e -> e.getOrdenId() != ordenId);
             }
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_orden.setCellValueFactory(new PropertyValueFactory<>("usuarioNombre"));
-            col_direccion.setCellValueFactory(new PropertyValueFactory<>("direccionNombre"));
+            col_orden.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getOrdenId() + ")"));
+            col_direccion.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getDireccionNombre() + " (" + data.getValue().getDireccionId() + ")"));
             col_empresa.setCellValueFactory(new PropertyValueFactory<>("empresaEnvio"));
             col_tracking.setCellValueFactory(new PropertyValueFactory<>("codigoTracking"));
             col_envio.setCellValueFactory(new PropertyValueFactory<>("fechaEnvio"));
             col_estimada.setCellValueFactory(new PropertyValueFactory<>("fechaEntregaEstimada"));
             col_entrega.setCellValueFactory(new PropertyValueFactory<>("fechaEntregaReal"));
             tbl_Lista.setItems(lista);
+            col_orden.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getOrdenId() + ")"));
+            col_direccion.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getDireccionNombre() + " (" + data.getValue().getDireccionId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
+++ b/src/proyectobd/EnviosGui/Lst_Envios_GuiController.java
@@ -69,12 +69,6 @@ public class Lst_Envios_GuiController implements Initializable {
             col_estimada.setCellValueFactory(new PropertyValueFactory<>("fechaEntregaEstimada"));
             col_entrega.setCellValueFactory(new PropertyValueFactory<>("fechaEntregaReal"));
             tbl_Lista.setItems(lista);
-            col_orden.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getOrdenId() + ")"));
-            col_direccion.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getDireccionNombre() + " (" + data.getValue().getDireccionId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/EnviosGui/Mnt_Envios_Gui.fxml
+++ b/src/proyectobd/EnviosGui/Mnt_Envios_Gui.fxml
@@ -28,13 +28,13 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Orden:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_orden" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="Dirección:" GridPane.rowIndex="2" />
                   <ComboBox fx:id="cmb_direccion" GridPane.columnIndex="1" GridPane.rowIndex="2" />
                   <Label text="Empresa:" GridPane.rowIndex="3" />
-                  <TextField fx:id="txt_empresa" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <ComboBox fx:id="cmb_empresa" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                   <Label text="Tracking:" GridPane.rowIndex="4" />
                   <TextField fx:id="txt_tracking" GridPane.columnIndex="1" GridPane.rowIndex="4" />
                   <Label text="Fecha Envio:" GridPane.rowIndex="5" />

--- a/src/proyectobd/EnviosGui/Mnt_Envios_GuiController.java
+++ b/src/proyectobd/EnviosGui/Mnt_Envios_GuiController.java
@@ -34,7 +34,7 @@ public class Mnt_Envios_GuiController implements Initializable {
     @FXML private TextField txt_id;
     @FXML private ComboBox<OrdenDTO> cmb_orden;
     @FXML private ComboBox<DireccionDTO> cmb_direccion;
-    @FXML private TextField txt_empresa;
+    @FXML private ComboBox<String> cmb_empresa;
     @FXML private TextField txt_tracking;
     @FXML private DatePicker dp_envio;
     @FXML private DatePicker dp_estimada;
@@ -56,7 +56,7 @@ public class Mnt_Envios_GuiController implements Initializable {
                 EnvioDTO dto = new EnvioDTO();
                 dto.setOrdenId(cmb_orden.getValue().getId());
                 dto.setDireccionId(cmb_direccion.getValue().getId());
-                dto.setEmpresaEnvio(txt_empresa.getText());
+                dto.setEmpresaEnvio(cmb_empresa.getValue());
                 dto.setCodigoTracking(txt_tracking.getText());
                 dto.setFechaEnvio(Timestamp.valueOf(dp_envio.getValue().atStartOfDay()));
                 dto.setFechaEntregaEstimada(Timestamp.valueOf(dp_estimada.getValue().atStartOfDay()));
@@ -74,7 +74,7 @@ public class Mnt_Envios_GuiController implements Initializable {
             EnvioDTO dto = (EnvioDTO) stage.getUserData();
             dto.setOrdenId(cmb_orden.getValue().getId());
             dto.setDireccionId(cmb_direccion.getValue().getId());
-            dto.setEmpresaEnvio(txt_empresa.getText());
+            dto.setEmpresaEnvio(cmb_empresa.getValue());
             dto.setCodigoTracking(txt_tracking.getText());
             dto.setFechaEnvio(Timestamp.valueOf(dp_envio.getValue().atStartOfDay()));
             dto.setFechaEntregaEstimada(Timestamp.valueOf(dp_estimada.getValue().atStartOfDay()));
@@ -133,6 +133,9 @@ public class Mnt_Envios_GuiController implements Initializable {
             DireccionDAO ddao = new DireccionDAO();
             direcciones.addAll(ddao.ListarDirecciones());
             cmb_direccion.setItems(direcciones);
+
+            ObservableList<String> empresas = FXCollections.observableArrayList("Servientrega", "Tramaco", "Correos Ecuador");
+            cmb_empresa.setItems(empresas);
         } catch (Exception ex) {
             fu.MostrarAlertas("Error", ex.toString());
         }
@@ -150,7 +153,7 @@ public class Mnt_Envios_GuiController implements Initializable {
             for(DireccionDTO d : cmb_direccion.getItems()){
                 if(d.getId() == dto.getDireccionId()){ cmb_direccion.setValue(d); break; }
             }
-            txt_empresa.setText(dto.getEmpresaEnvio());
+            cmb_empresa.setValue(dto.getEmpresaEnvio());
             txt_tracking.setText(dto.getCodigoTracking());
             dp_envio.setValue(dto.getFechaEnvio().toLocalDateTime().toLocalDate());
             dp_estimada.setValue(dto.getFechaEntregaEstimada().toLocalDateTime().toLocalDate());
@@ -159,6 +162,11 @@ public class Mnt_Envios_GuiController implements Initializable {
             dp_envio.setValue(java.time.LocalDate.now());
             dp_estimada.setValue(java.time.LocalDate.now());
             dp_entrega.setValue(java.time.LocalDate.now());
+            txt_tracking.setText(generarTracking());
         }
+    }
+
+    private String generarTracking(){
+        return "TRK" + System.currentTimeMillis();
     }
 }

--- a/src/proyectobd/EnviosGui/Mnt_Envios_GuiController.java
+++ b/src/proyectobd/EnviosGui/Mnt_Envios_GuiController.java
@@ -45,6 +45,9 @@ public class Mnt_Envios_GuiController implements Initializable {
         Platform.runLater(() -> {
             cargarCombos();
             cargarDatos();
+            cmb_empresa.valueProperty().addListener((o,oldV,newV)->{
+                if(!actualizar) txt_tracking.setText(generarTracking(newV));
+            });
         });
     }
 
@@ -162,11 +165,13 @@ public class Mnt_Envios_GuiController implements Initializable {
             dp_envio.setValue(java.time.LocalDate.now());
             dp_estimada.setValue(java.time.LocalDate.now());
             dp_entrega.setValue(java.time.LocalDate.now());
-            txt_tracking.setText(generarTracking());
+            txt_tracking.setText(generarTracking(cmb_empresa.getValue()));
         }
     }
 
-    private String generarTracking(){
-        return "TRK" + System.currentTimeMillis();
+    private String generarTracking(String empresa){
+        if(empresa == null) empresa = "GEN";
+        String pref = empresa.substring(0, Math.min(3, empresa.length())).toUpperCase();
+        return pref + System.currentTimeMillis();
     }
 }

--- a/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml
+++ b/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml
@@ -28,7 +28,7 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Producto:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_producto" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="URL:" GridPane.rowIndex="2" />

--- a/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml
+++ b/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_Gui.fxml
@@ -34,7 +34,7 @@
                   <Label text="URL:" GridPane.rowIndex="2" />
                   <TextField fx:id="txt_url" GridPane.columnIndex="1" GridPane.rowIndex="2" />
                   <Label text="Principal:" GridPane.rowIndex="3" />
-                  <TextField fx:id="txt_principal" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                  <CheckBox fx:id="chk_principal" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                </children>
             </GridPane>
          </center>

--- a/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_GuiController.java
+++ b/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_GuiController.java
@@ -12,6 +12,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
 import javafx.scene.control.TextField;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.CheckBox;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.layout.AnchorPane;
@@ -30,13 +31,18 @@ public class Mnt_ImagenesProducto_GuiController implements Initializable {
     @FXML private TextField txt_id;
     @FXML private ComboBox<ProductoDTO> cmb_producto;
     @FXML private TextField txt_url;
-    @FXML private TextField txt_principal;
+    @FXML private CheckBox chk_principal;
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         Platform.runLater(() -> {
             cargarCombos();
             cargarDatos();
+            cmb_producto.valueProperty().addListener((o,oldV,newV)->{
+                if(!actualizar && newV!=null){
+                    chk_principal.setSelected(!existePrincipal(newV.getId()));
+                }
+            });
         });
     }
 
@@ -47,7 +53,12 @@ public class Mnt_ImagenesProducto_GuiController implements Initializable {
                 ImagenProductoDTO dto = new ImagenProductoDTO();
                 dto.setProductoId(cmb_producto.getValue().getId());
                 dto.setUrl(txt_url.getText());
-                dto.setEsPrincipal(Boolean.parseBoolean(txt_principal.getText()));
+                boolean principal = chk_principal.isSelected();
+                if(!existePrincipal(cmb_producto.getValue().getId())){
+                    principal = true;
+                    chk_principal.setSelected(true);
+                }
+                dto.setEsPrincipal(principal);
                 int id = dao.InsertarImagen(dto);
                 if(id>0){
                     txt_id.setText(Integer.toString(id));
@@ -61,7 +72,7 @@ public class Mnt_ImagenesProducto_GuiController implements Initializable {
             ImagenProductoDTO dto = (ImagenProductoDTO) stage.getUserData();
             dto.setProductoId(cmb_producto.getValue().getId());
             dto.setUrl(txt_url.getText());
-            dto.setEsPrincipal(Boolean.parseBoolean(txt_principal.getText()));
+            dto.setEsPrincipal(chk_principal.isSelected());
             try{
                 dao.ActualizarImagen(dto);
                 btn_Grabar.setDisable(true);
@@ -97,7 +108,15 @@ public class Mnt_ImagenesProducto_GuiController implements Initializable {
                 if(p.getId() == dto.getProductoId()){ cmb_producto.setValue(p); break; }
             }
             txt_url.setText(dto.getUrl());
-            txt_principal.setText(Boolean.toString(dto.isEsPrincipal()));
+            chk_principal.setSelected(dto.isEsPrincipal());
         }
+    }
+
+    private boolean existePrincipal(int productoId){
+        ImagenProductoDAO dao = new ImagenProductoDAO();
+        for(ImagenProductoDTO img : dao.ListarImagenes(productoId)){
+            if(img.isEsPrincipal()) return true;
+        }
+        return false;
     }
 }

--- a/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_Gui.fxml
+++ b/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_Gui.fxml
@@ -41,7 +41,7 @@
             <columns>
               <TableColumn fx:id="col_id" prefWidth="50.0" text="ID" />
               <TableColumn fx:id="col_lista" prefWidth="75.0" text="Lista" />
-              <TableColumn fx:id="col_variante" prefWidth="75.0" text="Variante" />
+              <TableColumn fx:id="col_variante" prefWidth="250.0" text="Variante" />
               <TableColumn fx:id="col_cantidad" prefWidth="75.0" text="Cantidad" />
             </columns>
             <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>

--- a/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_GuiController.java
+++ b/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_GuiController.java
@@ -54,10 +54,6 @@ public class Lst_ListaDeseoItems_GuiController implements Initializable {
                         " (" + data.getValue().getVarianteId() + ")"));
             col_cantidad.setCellValueFactory(new PropertyValueFactory<>("cantidad"));
             tbl_Lista.setItems(lista);
-            col_variante.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getVarianteSku() + " - " + data.getValue().getProductoNombre() +
-                        " (" + data.getValue().getVarianteId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_GuiController.java
+++ b/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_GuiController.java
@@ -27,7 +27,7 @@ public class Lst_ListaDeseoItems_GuiController implements Initializable {
     @FXML private TableView<ListaDeseoItemDTO> tbl_Lista;
     @FXML private TableColumn<ListaDeseoItemDTO, Integer> col_id;
     @FXML private TableColumn<ListaDeseoItemDTO, Integer> col_lista;
-    @FXML private TableColumn<ListaDeseoItemDTO, Integer> col_variante;
+    @FXML private TableColumn<ListaDeseoItemDTO, String> col_variante;
     @FXML private TableColumn<ListaDeseoItemDTO, Integer> col_cantidad;
 
     FeedbackListaDeseoItem fu = new FeedbackListaDeseoItem();
@@ -48,9 +48,16 @@ public class Lst_ListaDeseoItems_GuiController implements Initializable {
             ObservableList<ListaDeseoItemDTO> lista = dao.ListarItems(idLista);
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
             col_lista.setCellValueFactory(new PropertyValueFactory<>("listaDeseosId"));
-            col_variante.setCellValueFactory(new PropertyValueFactory<>("varianteId"));
+            col_variante.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getVarianteSku() + " - " + data.getValue().getProductoNombre() +
+                        " (" + data.getValue().getVarianteId() + ")"));
             col_cantidad.setCellValueFactory(new PropertyValueFactory<>("cantidad"));
             tbl_Lista.setItems(lista);
+            col_variante.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getVarianteSku() + " - " + data.getValue().getProductoNombre() +
+                        " (" + data.getValue().getVarianteId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_GuiController.java
+++ b/src/proyectobd/ListaDeseoItemsGui/Lst_ListaDeseoItems_GuiController.java
@@ -35,6 +35,7 @@ public class Lst_ListaDeseoItems_GuiController implements Initializable {
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         txt_Buscar.textProperty().addListener((obs, oldV, newV) -> { call_Buscar(); });
+        call_Buscar();
     }
 
     public void call_CerrarVentana(){

--- a/src/proyectobd/ListaDeseoItemsGui/Mnt_ListaDeseoItems_Gui.fxml
+++ b/src/proyectobd/ListaDeseoItemsGui/Mnt_ListaDeseoItems_Gui.fxml
@@ -28,7 +28,7 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Lista:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_lista" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="Variante:" GridPane.rowIndex="2" />

--- a/src/proyectobd/ListaDeseoItemsGui/Mnt_ListaDeseoItems_GuiController.java
+++ b/src/proyectobd/ListaDeseoItemsGui/Mnt_ListaDeseoItems_GuiController.java
@@ -44,6 +44,7 @@ public class Mnt_ListaDeseoItems_GuiController implements Initializable {
 
     public void call_Grabar(){
         ListaDeseoItemDAO dao = new ListaDeseoItemDAO();
+        if(!validarDatos()) return;
         if(!actualizar){
             try{
                 ListaDeseoItemDTO dto = new ListaDeseoItemDTO();
@@ -108,5 +109,27 @@ public class Mnt_ListaDeseoItems_GuiController implements Initializable {
             }
             txt_cantidad.setText(Integer.toString(dto.getCantidad()));
         }
+    }
+
+    private boolean validarDatos(){
+        if(cmb_lista.getValue()==null){
+            fu.datosInvalidos("Lista: seleccione un valor v\u00e1lido.");
+            return false;
+        }
+        if(cmb_variante.getValue()==null){
+            fu.datosInvalidos("Variante: seleccione un valor v\u00e1lido.");
+            return false;
+        }
+        try{
+            int c = Integer.parseInt(txt_cantidad.getText());
+            if(c <= 0){
+                fu.datosInvalidos("Cantidad debe ser positiva");
+                return false;
+            }
+        }catch(Exception e){
+            fu.datosInvalidos("Cantidad inv\u00e1lida");
+            return false;
+        }
+        return true;
     }
 }

--- a/src/proyectobd/ListasDeseosGui/Lst_ListasDeseos_Gui.fxml
+++ b/src/proyectobd/ListasDeseosGui/Lst_ListasDeseos_Gui.fxml
@@ -42,7 +42,7 @@
          <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
             <columns>
               <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-              <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
+              <TableColumn fx:id="col_usuario" prefWidth="200.0" text="Usuario" />
               <TableColumn fx:id="col_nombre" prefWidth="150.0" text="Nombre" />
               <TableColumn fx:id="col_creado" prefWidth="150.0" text="Creado" />
             </columns>

--- a/src/proyectobd/ListasDeseosGui/Lst_ListasDeseos_GuiController.java
+++ b/src/proyectobd/ListasDeseosGui/Lst_ListasDeseos_GuiController.java
@@ -26,7 +26,7 @@ public class Lst_ListasDeseos_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<ListaDeseoDTO> tbl_Lista;
     @FXML private TableColumn<ListaDeseoDTO, Integer> col_id;
-    @FXML private TableColumn<ListaDeseoDTO, Integer> col_usuario;
+    @FXML private TableColumn<ListaDeseoDTO, String> col_usuario;
     @FXML private TableColumn<ListaDeseoDTO, String> col_nombre;
     @FXML private TableColumn<ListaDeseoDTO, String> col_creado;
 
@@ -48,10 +48,15 @@ public class Lst_ListasDeseos_GuiController implements Initializable {
             ListaDeseoDAO dao = new ListaDeseoDAO();
             ObservableList<ListaDeseoDTO> lista = dao.ListarListas();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_usuario.setCellValueFactory(new PropertyValueFactory<>("usuarioId"));
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
             col_nombre.setCellValueFactory(new PropertyValueFactory<>("nombre"));
             col_creado.setCellValueFactory(new PropertyValueFactory<>("creadoEn"));
             tbl_Lista.setItems(lista);
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/ListasDeseosGui/Lst_ListasDeseos_GuiController.java
+++ b/src/proyectobd/ListasDeseosGui/Lst_ListasDeseos_GuiController.java
@@ -54,9 +54,6 @@ public class Lst_ListasDeseos_GuiController implements Initializable {
             col_nombre.setCellValueFactory(new PropertyValueFactory<>("nombre"));
             col_creado.setCellValueFactory(new PropertyValueFactory<>("creadoEn"));
             tbl_Lista.setItems(lista);
-            col_usuario.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/OrdenItemsGui/Lst_OrdenItems_GuiController.java
+++ b/src/proyectobd/OrdenItemsGui/Lst_OrdenItems_GuiController.java
@@ -15,6 +15,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackOrdenItem;
 
@@ -48,7 +49,10 @@ public class Lst_OrdenItems_GuiController implements Initializable {
             ObservableList<OrdenItemDTO> lista = dao.ListarItems(idCarrito);
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
             col_orden.setCellValueFactory(new PropertyValueFactory<>("ordenId"));
-            col_variante.setCellValueFactory(new PropertyValueFactory<>("varianteSku"));
+            col_variante.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getVarianteSku() + " - " + data.getValue().getProductoNombre() +
+                        " (" + data.getValue().getVarianteId() + ")"));
             col_cantidad.setCellValueFactory(new PropertyValueFactory<>("cantidad"));
             tbl_Lista.setItems(lista);
         }catch(Exception ex){

--- a/src/proyectobd/OrdenItemsGui/Lst_OrdenItems_GuiController.java
+++ b/src/proyectobd/OrdenItemsGui/Lst_OrdenItems_GuiController.java
@@ -36,6 +36,7 @@ public class Lst_OrdenItems_GuiController implements Initializable {
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         txt_Buscar.textProperty().addListener((obs, oldV, newV) -> { call_Buscar(); });
+        call_Buscar();
     }
 
     public void call_CerrarVentana(){

--- a/src/proyectobd/OrdenItemsGui/Lst_OrdenItems_GuiController.java
+++ b/src/proyectobd/OrdenItemsGui/Lst_OrdenItems_GuiController.java
@@ -27,7 +27,7 @@ public class Lst_OrdenItems_GuiController implements Initializable {
     @FXML private TableView<OrdenItemDTO> tbl_Lista;
     @FXML private TableColumn<OrdenItemDTO, Integer> col_id;
     @FXML private TableColumn<OrdenItemDTO, Integer> col_orden;
-    @FXML private TableColumn<OrdenItemDTO, Integer> col_variante;
+    @FXML private TableColumn<OrdenItemDTO, String> col_variante;
     @FXML private TableColumn<OrdenItemDTO, Integer> col_cantidad;
 
     FeedbackOrdenItem fu = new FeedbackOrdenItem();
@@ -48,7 +48,7 @@ public class Lst_OrdenItems_GuiController implements Initializable {
             ObservableList<OrdenItemDTO> lista = dao.ListarItems(idCarrito);
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
             col_orden.setCellValueFactory(new PropertyValueFactory<>("ordenId"));
-            col_variante.setCellValueFactory(new PropertyValueFactory<>("varianteId"));
+            col_variante.setCellValueFactory(new PropertyValueFactory<>("varianteSku"));
             col_cantidad.setCellValueFactory(new PropertyValueFactory<>("cantidad"));
             tbl_Lista.setItems(lista);
         }catch(Exception ex){

--- a/src/proyectobd/OrdenItemsGui/Mnt_OrdenItems_Gui.fxml
+++ b/src/proyectobd/OrdenItemsGui/Mnt_OrdenItems_Gui.fxml
@@ -28,7 +28,7 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Orden:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_orden" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="Variante:" GridPane.rowIndex="2" />

--- a/src/proyectobd/OrdenItemsGui/Mnt_OrdenItems_GuiController.java
+++ b/src/proyectobd/OrdenItemsGui/Mnt_OrdenItems_GuiController.java
@@ -44,6 +44,7 @@ public class Mnt_OrdenItems_GuiController implements Initializable {
 
     public void call_Grabar(){
         OrdenItemDAO dao = new OrdenItemDAO();
+        if(!validarDatos()) return;
         if(!actualizar){
             try{
                 OrdenItemDTO dto = new OrdenItemDTO();
@@ -108,5 +109,23 @@ public class Mnt_OrdenItems_GuiController implements Initializable {
             }
             txt_cantidad.setText(Integer.toString(dto.getCantidad()));
         }
+    }
+
+    private boolean validarDatos(){
+        if(cmb_orden.getValue()==null || cmb_variante.getValue()==null){
+            fu.datosInvalidos("Seleccione orden y variante válidas");
+            return false;
+        }
+        try{
+            int c = Integer.parseInt(txt_cantidad.getText());
+            if(c <= 0){
+                fu.datosInvalidos("Cantidad debe ser positiva");
+                return false;
+            }
+        }catch(Exception e){
+            fu.datosInvalidos("Cantidad inválida");
+            return false;
+        }
+        return true;
     }
 }

--- a/src/proyectobd/OrdenesGui/Lst_Ordenes_GuiController.java
+++ b/src/proyectobd/OrdenesGui/Lst_Ordenes_GuiController.java
@@ -15,6 +15,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackOrden;
 
@@ -49,11 +50,16 @@ public class Lst_Ordenes_GuiController implements Initializable {
             OrdenDAO dao = new OrdenDAO();
             ObservableList<OrdenDTO> lista = dao.ListarOrdenes();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_usuario.setCellValueFactory(new PropertyValueFactory<>("usuarioNombre"));
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
             col_estado.setCellValueFactory(new PropertyValueFactory<>("estado"));
             col_total.setCellValueFactory(new PropertyValueFactory<>("totalBruto"));
             col_fecha.setCellValueFactory(new PropertyValueFactory<>("fechaCreacion"));
             tbl_Lista.setItems(lista);
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/OrdenesGui/Lst_Ordenes_GuiController.java
+++ b/src/proyectobd/OrdenesGui/Lst_Ordenes_GuiController.java
@@ -26,7 +26,7 @@ public class Lst_Ordenes_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<OrdenDTO> tbl_Lista;
     @FXML private TableColumn<OrdenDTO, Integer> col_id;
-    @FXML private TableColumn<OrdenDTO, Integer> col_usuario;
+    @FXML private TableColumn<OrdenDTO, String> col_usuario;
     @FXML private TableColumn<OrdenDTO, String> col_estado;
     @FXML private TableColumn<OrdenDTO, Number> col_total;
     @FXML private TableColumn<OrdenDTO, String> col_fecha;
@@ -49,7 +49,7 @@ public class Lst_Ordenes_GuiController implements Initializable {
             OrdenDAO dao = new OrdenDAO();
             ObservableList<OrdenDTO> lista = dao.ListarOrdenes();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_usuario.setCellValueFactory(new PropertyValueFactory<>("usuarioId"));
+            col_usuario.setCellValueFactory(new PropertyValueFactory<>("usuarioNombre"));
             col_estado.setCellValueFactory(new PropertyValueFactory<>("estado"));
             col_total.setCellValueFactory(new PropertyValueFactory<>("totalBruto"));
             col_fecha.setCellValueFactory(new PropertyValueFactory<>("fechaCreacion"));

--- a/src/proyectobd/OrdenesGui/Lst_Ordenes_GuiController.java
+++ b/src/proyectobd/OrdenesGui/Lst_Ordenes_GuiController.java
@@ -57,9 +57,6 @@ public class Lst_Ordenes_GuiController implements Initializable {
             col_total.setCellValueFactory(new PropertyValueFactory<>("totalBruto"));
             col_fecha.setCellValueFactory(new PropertyValueFactory<>("fechaCreacion"));
             tbl_Lista.setItems(lista);
-            col_usuario.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/OrdenesGui/Mnt_Ordenes_Gui.fxml
+++ b/src/proyectobd/OrdenesGui/Mnt_Ordenes_Gui.fxml
@@ -28,7 +28,7 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Usuario:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="Estado:" GridPane.rowIndex="2" />

--- a/src/proyectobd/PagosGui/Lst_Pagos_GuiController.java
+++ b/src/proyectobd/PagosGui/Lst_Pagos_GuiController.java
@@ -15,6 +15,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackPago;
 
@@ -48,11 +49,16 @@ public class Lst_Pagos_GuiController implements Initializable {
             PagoDAO dao = new PagoDAO();
             ObservableList<PagoDTO> lista = dao.ListarPagos();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_orden.setCellValueFactory(new PropertyValueFactory<>("usuarioNombre"));
+            col_orden.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getOrdenId() + ")"));
             col_metodo.setCellValueFactory(new PropertyValueFactory<>("metodoPago"));
             col_monto.setCellValueFactory(new PropertyValueFactory<>("monto"));
             col_fecha.setCellValueFactory(new PropertyValueFactory<>("fechaPago"));
             tbl_Lista.setItems(lista);
+            col_orden.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getOrdenId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/PagosGui/Lst_Pagos_GuiController.java
+++ b/src/proyectobd/PagosGui/Lst_Pagos_GuiController.java
@@ -26,9 +26,9 @@ public class Lst_Pagos_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<PagoDTO> tbl_Lista;
     @FXML private TableColumn<PagoDTO, Integer> col_id;
-    @FXML private TableColumn<PagoDTO, Integer> col_orden;
-    @FXML private TableColumn<PagoDTO, Integer> col_metodo;
-    @FXML private TableColumn<PagoDTO, Integer> col_monto;
+    @FXML private TableColumn<PagoDTO, String> col_orden;
+    @FXML private TableColumn<PagoDTO, String> col_metodo;
+    @FXML private TableColumn<PagoDTO, Double> col_monto;
     @FXML private TableColumn<PagoDTO, String> col_fecha;
 
     FeedbackPago fu = new FeedbackPago();
@@ -48,7 +48,7 @@ public class Lst_Pagos_GuiController implements Initializable {
             PagoDAO dao = new PagoDAO();
             ObservableList<PagoDTO> lista = dao.ListarPagos();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_orden.setCellValueFactory(new PropertyValueFactory<>("ordenId"));
+            col_orden.setCellValueFactory(new PropertyValueFactory<>("usuarioNombre"));
             col_metodo.setCellValueFactory(new PropertyValueFactory<>("metodoPago"));
             col_monto.setCellValueFactory(new PropertyValueFactory<>("monto"));
             col_fecha.setCellValueFactory(new PropertyValueFactory<>("fechaPago"));

--- a/src/proyectobd/PagosGui/Lst_Pagos_GuiController.java
+++ b/src/proyectobd/PagosGui/Lst_Pagos_GuiController.java
@@ -37,6 +37,7 @@ public class Lst_Pagos_GuiController implements Initializable {
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         txt_Buscar.textProperty().addListener((obs, oldV, newV) -> { call_Buscar(); });
+        call_Buscar();
     }
 
     public void call_CerrarVentana(){

--- a/src/proyectobd/PagosGui/Lst_Pagos_GuiController.java
+++ b/src/proyectobd/PagosGui/Lst_Pagos_GuiController.java
@@ -57,9 +57,6 @@ public class Lst_Pagos_GuiController implements Initializable {
             col_monto.setCellValueFactory(new PropertyValueFactory<>("monto"));
             col_fecha.setCellValueFactory(new PropertyValueFactory<>("fechaPago"));
             tbl_Lista.setItems(lista);
-            col_orden.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getOrdenId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/PagosGui/Mnt_Pagos_Gui.fxml
+++ b/src/proyectobd/PagosGui/Mnt_Pagos_Gui.fxml
@@ -28,11 +28,11 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Orden:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_orden" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="Metodo:" GridPane.rowIndex="2" />
-                  <TextField fx:id="txt_metodo" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <ComboBox fx:id="cmb_metodo" GridPane.columnIndex="1" GridPane.rowIndex="2" />
                   <Label text="Monto:" GridPane.rowIndex="3" />
                   <TextField fx:id="txt_monto" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                   <Label text="Fecha:" GridPane.rowIndex="4" />

--- a/src/proyectobd/PagosGui/Mnt_Pagos_GuiController.java
+++ b/src/proyectobd/PagosGui/Mnt_Pagos_GuiController.java
@@ -31,7 +31,7 @@ public class Mnt_Pagos_GuiController implements Initializable {
     @FXML private Button btn_Cerrar;
     @FXML private TextField txt_id;
     @FXML private ComboBox<OrdenDTO> cmb_orden;
-    @FXML private TextField txt_metodo;
+    @FXML private ComboBox<String> cmb_metodo;
     @FXML private TextField txt_monto;
     @FXML private DatePicker dp_fecha;
 
@@ -45,11 +45,12 @@ public class Mnt_Pagos_GuiController implements Initializable {
 
     public void call_Grabar(){
         PagoDAO dao = new PagoDAO();
+        if(!validarDatos()) return;
         if(!actualizar){
             try{
                 PagoDTO dto = new PagoDTO();
                 dto.setOrdenId(cmb_orden.getValue().getId());
-                dto.setMetodoPago(txt_metodo.getText());
+                dto.setMetodoPago(cmb_metodo.getValue());
                 dto.setMonto(Double.parseDouble(txt_monto.getText()));
                 dto.setFechaPago(Timestamp.valueOf(dp_fecha.getValue().atStartOfDay()));
                 int id = dao.InsertarPago(dto);
@@ -64,7 +65,7 @@ public class Mnt_Pagos_GuiController implements Initializable {
             Stage stage = (Stage) Ap_Main.getScene().getWindow();
             PagoDTO dto = (PagoDTO) stage.getUserData();
             dto.setOrdenId(cmb_orden.getValue().getId());
-            dto.setMetodoPago(txt_metodo.getText());
+            dto.setMetodoPago(cmb_metodo.getValue());
             dto.setMonto(Double.parseDouble(txt_monto.getText()));
             dto.setFechaPago(Timestamp.valueOf(dp_fecha.getValue().atStartOfDay()));
             try{
@@ -87,6 +88,9 @@ public class Mnt_Pagos_GuiController implements Initializable {
             OrdenDAO odao = new OrdenDAO();
             ordenes.addAll(odao.ListarOrdenes());
             cmb_orden.setItems(ordenes);
+
+            ObservableList<String> metodos = FXCollections.observableArrayList("Efectivo", "Tarjeta", "Transferencia");
+            cmb_metodo.setItems(metodos);
         } catch (Exception ex) {
             fu.MostrarAlertas("Error", ex.toString());
         }
@@ -101,12 +105,38 @@ public class Mnt_Pagos_GuiController implements Initializable {
             for(OrdenDTO o : cmb_orden.getItems()){
                 if(o.getId() == dto.getOrdenId()){ cmb_orden.setValue(o); break; }
             }
-            txt_metodo.setText(dto.getMetodoPago());
+            cmb_metodo.setValue(dto.getMetodoPago());
             txt_monto.setText(Double.toString(dto.getMonto()));
             dp_fecha.setValue(dto.getFechaPago().toLocalDateTime().toLocalDate());
         }
         else{
             dp_fecha.setValue(java.time.LocalDate.now());
         }
+    }
+
+    private boolean validarDatos(){
+        if(cmb_orden.getValue()==null){
+            fu.datosInvalidos("Seleccione una orden válida");
+            return false;
+        }
+        if(cmb_metodo.getValue()==null){
+            fu.datosInvalidos("Seleccione un método de pago");
+            return false;
+        }
+        try{
+            double m = Double.parseDouble(txt_monto.getText());
+            if(m < 0){
+                fu.datosInvalidos("Monto no puede ser negativo");
+                return false;
+            }
+        }catch(Exception e){
+            fu.datosInvalidos("Monto inválido");
+            return false;
+        }
+        if(dp_fecha.getValue().isBefore(java.time.LocalDate.now())){
+            fu.datosInvalidos("Fecha de pago no puede ser anterior a hoy");
+            return false;
+        }
+        return true;
     }
 }

--- a/src/proyectobd/ProductosGui/Mnt_Productos_Gui.fxml
+++ b/src/proyectobd/ProductosGui/Mnt_Productos_Gui.fxml
@@ -55,7 +55,7 @@
                                     <Button fx:id="btn_BuscarImagen" onAction="#call_SeleccionarImagen" text="..." />
                                 </HBox>
                                 <Label text="Activo:" GridPane.rowIndex="6" />
-                                <TextField fx:id="txt_activo" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+                                <ComboBox fx:id="cmb_activo" GridPane.columnIndex="1" GridPane.rowIndex="6" />
                             </children>
                         </GridPane>
                     </HBox>

--- a/src/proyectobd/ProductosGui/Mnt_Productos_Gui.fxml
+++ b/src/proyectobd/ProductosGui/Mnt_Productos_Gui.fxml
@@ -40,7 +40,7 @@
                             </columnConstraints>
                             <children>
                                 <Label text="ID:" />
-                                <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                                <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                                 <Label text="Vendedor:" GridPane.rowIndex="1" />
                                 <ComboBox fx:id="cmb_vendedor" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                                 <Label text="Categoría:" GridPane.rowIndex="2" />

--- a/src/proyectobd/ProductosGui/Mnt_Productos_GuiController.java
+++ b/src/proyectobd/ProductosGui/Mnt_Productos_GuiController.java
@@ -43,7 +43,7 @@ public class Mnt_Productos_GuiController implements Initializable {
     @FXML private ImageView img_principal;
     @FXML private TextField txt_titulo;
     @FXML private TextField txt_descripcion;
-    @FXML private TextField txt_activo;
+    @FXML private ComboBox<String> cmb_activo;
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
@@ -56,6 +56,7 @@ public class Mnt_Productos_GuiController implements Initializable {
 
     public void call_Grabar(){
         ProductoDAO dao = new ProductoDAO();
+        if(!validarDatos()) return;
         if(!actualizar){
             try{
                 ProductoDTO dto = new ProductoDTO();
@@ -64,7 +65,7 @@ public class Mnt_Productos_GuiController implements Initializable {
                 dto.setTitulo(txt_titulo.getText());
                 dto.setDescripcion(txt_descripcion.getText());
                 dto.setCreadoEn(new Timestamp(System.currentTimeMillis()));
-                dto.setActivo(Boolean.parseBoolean(txt_activo.getText()));
+                dto.setActivo("Activo".equals(cmb_activo.getValue()));
                 int id = dao.InsertarProducto(dto);
                 if(id>0){
                     txt_id.setText(Integer.toString(id));
@@ -81,7 +82,7 @@ public class Mnt_Productos_GuiController implements Initializable {
             dto.setCategoriaId(cmb_categoria.getValue().getId());
             dto.setTitulo(txt_titulo.getText());
             dto.setDescripcion(txt_descripcion.getText());
-            dto.setActivo(Boolean.parseBoolean(txt_activo.getText()));
+            dto.setActivo("Activo".equals(cmb_activo.getValue()));
             try{
                 dao.ActualizarProducto(dto);
                 guardarImagen(dto.getId());
@@ -108,6 +109,10 @@ public class Mnt_Productos_GuiController implements Initializable {
             CategoriaDAO cdao = new CategoriaDAO();
             categorias.addAll(cdao.ListarCategorias());
             cmb_categoria.setItems(categorias);
+
+            ObservableList<String> estados = FXCollections.observableArrayList("Activo", "Inactivo");
+            cmb_activo.setItems(estados);
+            cmb_activo.getSelectionModel().selectFirst();
         } catch (Exception ex) {
             fu.MostrarAlertas("Error", "No se pudieron cargar los cat\u00e1logos: " + ex.getMessage());
         }
@@ -127,7 +132,7 @@ public class Mnt_Productos_GuiController implements Initializable {
             }
             txt_titulo.setText(dto.getTitulo());
             txt_descripcion.setText(dto.getDescripcion());
-            txt_activo.setText(Boolean.toString(dto.isActivo()));
+            cmb_activo.setValue(dto.isActivo() ? "Activo" : "Inactivo");
             cargarImagenPrincipal(dto.getId());
         }
     }
@@ -175,5 +180,25 @@ public class Mnt_Productos_GuiController implements Initializable {
             txt_imagen.setText(f.getAbsolutePath());
             img_principal.setImage(new Image(f.toURI().toString()));
         }
+    }
+
+    private boolean validarDatos(){
+        if(cmb_vendedor.getValue()==null){
+            fu.datosInvalidos("Seleccione un vendedor v\u00e1lido");
+            return false;
+        }
+        if(cmb_categoria.getValue()==null){
+            fu.datosInvalidos("Seleccione una categor\u00eda v\u00e1lida");
+            return false;
+        }
+        if(txt_titulo.getText().trim().isEmpty()){
+            fu.datosInvalidos("El t\u00edtulo es obligatorio");
+            return false;
+        }
+        if(txt_descripcion.getText().trim().isEmpty()){
+            fu.datosInvalidos("La descripci\u00f3n es obligatoria");
+            return false;
+        }
+        return true;
     }
 }

--- a/src/proyectobd/ResenasGui/Lst_Resenas_Gui.fxml
+++ b/src/proyectobd/ResenasGui/Lst_Resenas_Gui.fxml
@@ -36,8 +36,8 @@
          <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
                <columns>
                   <TableColumn fx:id="col_id" prefWidth="75.0" text="ID"/>
-                  <TableColumn fx:id="col_producto" prefWidth="75.0" text="Producto"/>
-                  <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario"/>
+                  <TableColumn fx:id="col_producto" prefWidth="150.0" text="Producto"/>
+                  <TableColumn fx:id="col_usuario" prefWidth="150.0" text="Usuario"/>
                   <TableColumn fx:id="col_rating" prefWidth="75.0" text="Rating"/>
                   <TableColumn fx:id="col_fecha" prefWidth="150.0" text="Fecha"/>
                </columns>

--- a/src/proyectobd/ResenasGui/Lst_Resenas_GuiController.java
+++ b/src/proyectobd/ResenasGui/Lst_Resenas_GuiController.java
@@ -50,8 +50,12 @@ public class Lst_Resenas_GuiController implements Initializable {
             ResenaDAO dao = new ResenaDAO();
             ObservableList<ResenaDTO> lista = dao.ListarResenas();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_producto.setCellValueFactory(new PropertyValueFactory<>("productoId"));
-            col_usuario.setCellValueFactory(new PropertyValueFactory<>("usuarioId"));
+            col_producto.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getProductoNombre() + " (" + data.getValue().getProductoId() + ")"));
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
             col_rating.setCellValueFactory(new PropertyValueFactory<>("rating"));
             col_fecha.setCellValueFactory(new PropertyValueFactory<>("fecha"));
             tbl_Lista.setItems(lista);

--- a/src/proyectobd/ResenasGui/Lst_Resenas_GuiController.java
+++ b/src/proyectobd/ResenasGui/Lst_Resenas_GuiController.java
@@ -27,8 +27,8 @@ public class Lst_Resenas_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<ResenaDTO> tbl_Lista;
     @FXML private TableColumn<ResenaDTO, Integer> col_id;
-    @FXML private TableColumn<ResenaDTO, Integer> col_producto;
-    @FXML private TableColumn<ResenaDTO, Integer> col_usuario;
+    @FXML private TableColumn<ResenaDTO, String> col_producto;
+    @FXML private TableColumn<ResenaDTO, String> col_usuario;
     @FXML private TableColumn<ResenaDTO, Integer> col_rating;
     @FXML private TableColumn<ResenaDTO, Timestamp> col_fecha;
 

--- a/src/proyectobd/ResenasGui/Mnt_Resenas_Gui.fxml
+++ b/src/proyectobd/ResenasGui/Mnt_Resenas_Gui.fxml
@@ -28,7 +28,7 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Producto:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_producto" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="Usuario:" GridPane.rowIndex="2" />

--- a/src/proyectobd/ResenasGui/Mnt_Resenas_GuiController.java
+++ b/src/proyectobd/ResenasGui/Mnt_Resenas_GuiController.java
@@ -76,6 +76,11 @@ public class Mnt_Resenas_GuiController implements Initializable {
             dp_fecha.requestFocus();
             return;
         }
+        if(contieneOfensivo(txt_comentario.getText())){
+            fu.datosInvalidos("Comentario contiene lenguaje ofensivo");
+            txt_comentario.requestFocus();
+            return;
+        }
 
         if(!actualizar){
             try{
@@ -159,5 +164,15 @@ public class Mnt_Resenas_GuiController implements Initializable {
                 cmb_rating.getSelectionModel().selectFirst();
             }
         }
+    }
+
+    private boolean contieneOfensivo(String comentario){
+        if(comentario == null) return false;
+        String lower = comentario.toLowerCase();
+        String[] malas = {"tonto","idiota","malo"};
+        for(String m: malas){
+            if(lower.contains(m)) return true;
+        }
+        return false;
     }
 }

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
@@ -30,7 +30,7 @@
                <children>
                   <ImageView fx:id="img_perfil" fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true" style="-fx-border-color: black; -fx-border-width: 1; -fx-background-color: lightgray;" />
                   <Label text="ID:" GridPane.columnIndex="1" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="2" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="2" editable="false" />
                   <Label text="Rol:" GridPane.rowIndex="1" GridPane.columnIndex="1" />
                   <ComboBox fx:id="cmb_rol" GridPane.columnIndex="2" GridPane.rowIndex="1" />
                   <Label text="Nombre:" GridPane.rowIndex="2" GridPane.columnIndex="1" />

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_Gui.fxml
@@ -6,17 +6,17 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane styleClass="main-pane" prefHeight="480.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Mnt_Usuarios_GuiController">
+<AnchorPane styleClass="main-pane" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="proyectobd.UsuariosGui.Mnt_Usuarios_GuiController">
    <stylesheets>
       <URL value="@/proyectobd/styles/app.css" />
    </stylesheets>
    <children>
       <BorderPane fx:id="Ap_Main" AnchorPane.topAnchor="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
          <top>
-            <HBox alignment="CENTER_LEFT" prefHeight="40.0" styleClass="header-section" spacing="10.0">
+            <HBox alignment="CENTER_LEFT" prefHeight="50.0" styleClass="header-section" spacing="10.0">
                <padding><Insets left="10.0" right="10.0"/></padding>
                <Label text="Mantenimiento de Usuarios" styleClass="header-title">
-                  <font><Font size="18.0"/></font>
+                  <font><Font size="24.0"/></font>
                </Label>
             </HBox>
          </top>
@@ -24,7 +24,7 @@
             <GridPane hgap="10.0" vgap="10.0">
                <padding><Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/></padding>
                <columnConstraints>
-                  <ColumnConstraints minWidth="120.0" />
+                  <ColumnConstraints minWidth="80.0" />
                   <ColumnConstraints hgrow="ALWAYS" />
                </columnConstraints>
                <children>

--- a/src/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_Gui.fxml
+++ b/src/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_Gui.fxml
@@ -28,11 +28,11 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Producto:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_producto" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="SKU:" GridPane.rowIndex="2" />
-                  <TextField fx:id="txt_sku" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <TextField fx:id="txt_sku" GridPane.columnIndex="1" GridPane.rowIndex="2" editable="false" />
                   <Label text="Precio:" GridPane.rowIndex="3" />
                   <TextField fx:id="txt_precio" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                   <Label text="Stock:" GridPane.rowIndex="4" />

--- a/src/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_GuiController.java
+++ b/src/proyectobd/VarianteProductoGui/Mnt_VariantesProducto_GuiController.java
@@ -38,6 +38,8 @@ public class Mnt_VariantesProducto_GuiController implements Initializable {
         Platform.runLater(() -> {
             cargarCombos();
             cargarDatos();
+            txt_id.setDisable(true);
+            txt_sku.setDisable(true);
         });
     }
 
@@ -47,7 +49,7 @@ public class Mnt_VariantesProducto_GuiController implements Initializable {
             try{
                 VarianteProductoDTO dto = new VarianteProductoDTO();
                 dto.setProductoId(cmb_producto.getValue().getId());
-                dto.setSku(txt_sku.getText());
+                dto.setSku(generarSku());
                 dto.setPrecio(Double.parseDouble(txt_precio.getText()));
                 dto.setStock(Integer.parseInt(txt_stock.getText()));
                 int id = dao.InsertarVariante(dto);
@@ -102,6 +104,12 @@ public class Mnt_VariantesProducto_GuiController implements Initializable {
             txt_sku.setText(dto.getSku());
             txt_precio.setText(Double.toString(dto.getPrecio()));
             txt_stock.setText(Integer.toString(dto.getStock()));
+        } else {
+            txt_sku.setText(generarSku());
         }
+    }
+
+    private String generarSku(){
+        return "SKU" + System.currentTimeMillis();
     }
 }

--- a/src/proyectobd/VendedoresGui/Lst_Vendedores_Gui.fxml
+++ b/src/proyectobd/VendedoresGui/Lst_Vendedores_Gui.fxml
@@ -42,7 +42,7 @@
          <TableView fx:id="tbl_Lista" VBox.vgrow="ALWAYS">
             <columns>
               <TableColumn fx:id="col_id" prefWidth="75.0" text="ID" />
-              <TableColumn fx:id="col_usuario" prefWidth="75.0" text="Usuario" />
+              <TableColumn fx:id="col_usuario" prefWidth="150.0" text="Usuario" />
               <TableColumn fx:id="col_nombre" prefWidth="150.0" text="Tienda" />
               <TableColumn fx:id="col_calificacion" prefWidth="100.0" text="Calificación" />
             </columns>

--- a/src/proyectobd/VendedoresGui/Lst_Vendedores_GuiController.java
+++ b/src/proyectobd/VendedoresGui/Lst_Vendedores_GuiController.java
@@ -74,9 +74,6 @@ public class Lst_Vendedores_GuiController implements Initializable {
                 }
             }
             tbl_Lista.setItems(lista);
-            col_usuario.setCellValueFactory(data ->
-                    new javafx.beans.property.ReadOnlyStringWrapper(
-                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/VendedoresGui/Lst_Vendedores_GuiController.java
+++ b/src/proyectobd/VendedoresGui/Lst_Vendedores_GuiController.java
@@ -26,7 +26,7 @@ public class Lst_Vendedores_GuiController implements Initializable {
     @FXML private TextField txt_Buscar;
     @FXML private TableView<VendedorDTO> tbl_Lista;
     @FXML private TableColumn<VendedorDTO, Integer> col_id;
-    @FXML private TableColumn<VendedorDTO, Integer> col_usuario;
+    @FXML private TableColumn<VendedorDTO, String> col_usuario;
     @FXML private TableColumn<VendedorDTO, String> col_nombre;
     @FXML private TableColumn<VendedorDTO, Number> col_calificacion;
 
@@ -48,7 +48,9 @@ public class Lst_Vendedores_GuiController implements Initializable {
             VendedorDAO dao = new VendedorDAO();
             ObservableList<VendedorDTO> lista = dao.ListarVendedores();
             col_id.setCellValueFactory(new PropertyValueFactory<>("id"));
-            col_usuario.setCellValueFactory(new PropertyValueFactory<>("usuarioId"));
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
             col_nombre.setCellValueFactory(new PropertyValueFactory<>("nombreTienda"));
             col_calificacion.setCellValueFactory(new PropertyValueFactory<>("calificacionPromedio"));
             tbl_Lista.setItems(lista);
@@ -72,6 +74,9 @@ public class Lst_Vendedores_GuiController implements Initializable {
                 }
             }
             tbl_Lista.setItems(lista);
+            col_usuario.setCellValueFactory(data ->
+                    new javafx.beans.property.ReadOnlyStringWrapper(
+                        data.getValue().getUsuarioNombre() + " (" + data.getValue().getUsuarioId() + ")"));
         }catch(Exception ex){
             fu.MostrarAlertas("Error", ex.toString());
         }

--- a/src/proyectobd/VendedoresGui/Mnt_Vendedores_Gui.fxml
+++ b/src/proyectobd/VendedoresGui/Mnt_Vendedores_Gui.fxml
@@ -32,7 +32,7 @@
                   <Label text="Usuario ID:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="Nombre Tienda:" GridPane.rowIndex="2" />
-                  <TextField fx:id="txt_nombre" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                  <ComboBox fx:id="cmb_tienda" GridPane.columnIndex="1" GridPane.rowIndex="2" />
                   <Label text="Descripción:" GridPane.rowIndex="3" />
                   <TextField fx:id="txt_descripcion" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                   <Label text="Calificación:" GridPane.rowIndex="4" />

--- a/src/proyectobd/VendedoresGui/Mnt_Vendedores_Gui.fxml
+++ b/src/proyectobd/VendedoresGui/Mnt_Vendedores_Gui.fxml
@@ -28,7 +28,7 @@
                </columnConstraints>
                <children>
                   <Label text="ID:" />
-                  <TextField fx:id="txt_id" GridPane.columnIndex="1" />
+                  <TextField fx:id="txt_id" GridPane.columnIndex="1" editable="false" />
                   <Label text="Usuario ID:" GridPane.rowIndex="1" />
                   <ComboBox fx:id="cmb_usuario" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                   <Label text="Nombre Tienda:" GridPane.rowIndex="2" />

--- a/src/proyectobd/VendedoresGui/Mnt_Vendedores_GuiController.java
+++ b/src/proyectobd/VendedoresGui/Mnt_Vendedores_GuiController.java
@@ -29,7 +29,7 @@ public class Mnt_Vendedores_GuiController implements Initializable {
     @FXML private Button btn_Cerrar;
     @FXML private TextField txt_id;
     @FXML private ComboBox<UsuarioDTO> cmb_usuario;
-    @FXML private TextField txt_nombre;
+    @FXML private ComboBox<String> cmb_tienda;
     @FXML private TextField txt_descripcion;
     @FXML private TextField txt_calificacion;
 
@@ -48,7 +48,7 @@ public class Mnt_Vendedores_GuiController implements Initializable {
             try{
                 VendedorDTO dto = new VendedorDTO();
                 dto.setUsuarioId(cmb_usuario.getValue().getId());
-                dto.setNombreTienda(txt_nombre.getText());
+                dto.setNombreTienda(cmb_tienda.getValue());
                 dto.setDescripcion(txt_descripcion.getText());
                 dto.setCalificacionPromedio(new java.math.BigDecimal(txt_calificacion.getText()));
                 int id = dao.InsertarVendedor(dto);
@@ -63,7 +63,7 @@ public class Mnt_Vendedores_GuiController implements Initializable {
             Stage stage = (Stage) Ap_Main.getScene().getWindow();
             VendedorDTO dto = (VendedorDTO) stage.getUserData();
             dto.setUsuarioId(cmb_usuario.getValue().getId());
-            dto.setNombreTienda(txt_nombre.getText());
+            dto.setNombreTienda(cmb_tienda.getValue());
             dto.setDescripcion(txt_descripcion.getText());
             dto.setCalificacionPromedio(new java.math.BigDecimal(txt_calificacion.getText()));
             try{
@@ -89,7 +89,7 @@ public class Mnt_Vendedores_GuiController implements Initializable {
             for(UsuarioDTO u : cmb_usuario.getItems()){
                 if(u.getId() == dto.getUsuarioId()){ cmb_usuario.setValue(u); break; }
             }
-            txt_nombre.setText(dto.getNombreTienda());
+            cmb_tienda.setValue(dto.getNombreTienda());
             txt_descripcion.setText(dto.getDescripcion());
             txt_calificacion.setText(dto.getCalificacionPromedio().toString());
         }
@@ -101,6 +101,10 @@ public class Mnt_Vendedores_GuiController implements Initializable {
             UsuarioDAO udao = new UsuarioDAO();
             usuarios.addAll(udao.ListarUsuarios());
             cmb_usuario.setItems(usuarios);
+
+            ObservableList<String> tiendas = FXCollections.observableArrayList(
+                "Tienda Quito", "Tienda Guayaquil", "Tienda Cuenca", "Tienda Loja");
+            cmb_tienda.setItems(tiendas);
         } catch (Exception ex) {
             fu.MostrarAlertas("Error", ex.toString());
         }


### PR DESCRIPTION
## Summary
- fix missing imports in category maintenance FXML
- expose helper to fetch user by ID
- join users in vendor DAO
- show user name with ID in vendor listing
- show user name with ID in address list
- use combo boxes for city and province selections
- show user names in cart and wishlist tables
- display product info for cart and wishlist items
- join users and products in other DAOs
- add validation and automated fields in maintenance forms

## Testing
- `javac -version`


------
https://chatgpt.com/codex/tasks/task_e_687076d15580833293778fbb133612f7