### PR TITLE
Add profanity checks and canton dropdowns

### DIFF
--- a/src/dao/DireccionDAO.java
+++ b/src/dao/DireccionDAO.java
@@ -4,12 +4,22 @@ import dto.DireccionDTO;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import proyectobd.ParametrosGenerales.FeedbackVendedor; // use generic feedback
 
 public class DireccionDAO {
     FeedbackVendedor fu = new FeedbackVendedor();
+
+    private boolean tieneColumna(Connection conn, String tabla, String columna){
+        try(ResultSet rs = conn.getMetaData().getColumns(null, null, tabla, columna)){
+            return rs.next();
+        }catch(Exception ex){
+            return false;
+        }
+    }
 
     private boolean existeUsuario(int usuarioId){
         ConectorBD ConnBD = new ConectorBD();
@@ -34,7 +44,9 @@ public class DireccionDAO {
                      "FROM direcciones d JOIN usuarios u ON d.usuario_id=u.id " +
                      "ORDER BY d.id";
         try{
-            Statement st = ConnBD.AbrirConexionBD().createStatement();
+            Connection cn = ConnBD.AbrirConexionBD();
+            boolean hasCanton = tieneColumna(cn, "direcciones", "canton");
+            Statement st = cn.createStatement();
             ResultSet rs = st.executeQuery(sql);
             while(rs.next()){
                 DireccionDTO dto = new DireccionDTO();
@@ -44,7 +56,7 @@ public class DireccionDAO {
                 dto.setAlias(rs.getString("alias"));
                 dto.setDireccion(rs.getString("direccion"));
                 dto.setCiudad(rs.getString("ciudad"));
-                dto.setCanton(rs.getString("canton"));
+                if(hasCanton) dto.setCanton(rs.getString("canton"));
                 dto.setProvincia(rs.getString("provincia"));
                 dto.setCodigoPostal(rs.getString("codigo_postal"));
                 dto.setTelefonoContacto(rs.getString("telefono_contacto"));
@@ -64,7 +76,9 @@ public class DireccionDAO {
                      "FROM direcciones d JOIN usuarios u ON d.usuario_id=u.id " +
                      "WHERE d.ciudad LIKE '%"+criterio+"%' ORDER BY d.id";
         try{
-            Statement st = ConnBD.AbrirConexionBD().createStatement();
+            Connection cn = ConnBD.AbrirConexionBD();
+            boolean hasCanton = tieneColumna(cn, "direcciones", "canton");
+            Statement st = cn.createStatement();
             ResultSet rs = st.executeQuery(sql);
             while(rs.next()){
                 DireccionDTO dto = new DireccionDTO();
@@ -74,7 +88,7 @@ public class DireccionDAO {
                 dto.setAlias(rs.getString("alias"));
                 dto.setDireccion(rs.getString("direccion"));
                 dto.setCiudad(rs.getString("ciudad"));
-                dto.setCanton(rs.getString("canton"));
+                if(hasCanton) dto.setCanton(rs.getString("canton"));
                 dto.setProvincia(rs.getString("provincia"));
                 dto.setCodigoPostal(rs.getString("codigo_postal"));
                 dto.setTelefonoContacto(rs.getString("telefono_contacto"));
@@ -93,17 +107,27 @@ public class DireccionDAO {
                 fu.datosInvalidos("El usuario no existe");
                 return 0;
             }
-            String sql = "INSERT INTO direcciones(usuario_id, alias, direccion, ciudad, canton, provincia, codigo_postal, telefono_contacto) VALUES(?,?,?,?,?,?,?,?)";
             ConectorBD ConnBD = new ConectorBD();
-            PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            Connection cn = ConnBD.AbrirConexionBD();
+            boolean hasCanton = tieneColumna(cn, "direcciones", "canton");
+            String sql;
+            if(hasCanton){
+                sql = "INSERT INTO direcciones(usuario_id, alias, direccion, ciudad, canton, provincia, codigo_postal, telefono_contacto) VALUES(?,?,?,?,?,?,?,?)";
+            }else{
+                sql = "INSERT INTO direcciones(usuario_id, alias, direccion, ciudad, provincia, codigo_postal, telefono_contacto) VALUES(?,?,?,?,?,?,?)";
+            }
+            PreparedStatement ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             ps.setInt(1, dto.getUsuarioId());
             ps.setString(2, dto.getAlias());
             ps.setString(3, dto.getDireccion());
             ps.setString(4, dto.getCiudad());
-            ps.setString(5, dto.getCanton());
-            ps.setString(6, dto.getProvincia());
-            ps.setString(7, dto.getCodigoPostal());
-            ps.setString(8, dto.getTelefonoContacto());
+            int idx = 5;
+            if(hasCanton){
+                ps.setString(idx++, dto.getCanton());
+            }
+            ps.setString(idx++, dto.getProvincia());
+            ps.setString(idx++, dto.getCodigoPostal());
+            ps.setString(idx++, dto.getTelefonoContacto());
             ps.executeUpdate();
             ResultSet rs = ps.getGeneratedKeys();
             int codigo = 0;
@@ -123,18 +147,28 @@ public class DireccionDAO {
                 fu.datosInvalidos("El usuario no existe");
                 return 0;
             }
-            String sql = "UPDATE direcciones SET usuario_id=?, alias=?, direccion=?, ciudad=?, canton=?, provincia=?, codigo_postal=?, telefono_contacto=? WHERE id=?";
             ConectorBD ConnBD = new ConectorBD();
-            PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
+            Connection cn = ConnBD.AbrirConexionBD();
+            boolean hasCanton = tieneColumna(cn, "direcciones", "canton");
+            String sql;
+            if(hasCanton){
+                sql = "UPDATE direcciones SET usuario_id=?, alias=?, direccion=?, ciudad=?, canton=?, provincia=?, codigo_postal=?, telefono_contacto=? WHERE id=?";
+            }else{
+                sql = "UPDATE direcciones SET usuario_id=?, alias=?, direccion=?, ciudad=?, provincia=?, codigo_postal=?, telefono_contacto=? WHERE id=?";
+            }
+            PreparedStatement ps = cn.prepareStatement(sql);
             ps.setInt(1, dto.getUsuarioId());
             ps.setString(2, dto.getAlias());
             ps.setString(3, dto.getDireccion());
             ps.setString(4, dto.getCiudad());
-            ps.setString(5, dto.getCanton());
-            ps.setString(6, dto.getProvincia());
-            ps.setString(7, dto.getCodigoPostal());
-            ps.setString(8, dto.getTelefonoContacto());
-            ps.setInt(9, dto.getId());
+            int idx = 5;
+            if(hasCanton){
+                ps.setString(idx++, dto.getCanton());
+            }
+            ps.setString(idx++, dto.getProvincia());
+            ps.setString(idx++, dto.getCodigoPostal());
+            ps.setString(idx++, dto.getTelefonoContacto());
+            ps.setInt(idx, dto.getId());
             int registros = ps.executeUpdate();
             if(registros==0){
                 fu.datosInvalidos("Dirección no encontrada");

--- a/src/dao/DireccionDAO.java
+++ b/src/dao/DireccionDAO.java
@@ -44,6 +44,7 @@ public class DireccionDAO {
                 dto.setAlias(rs.getString("alias"));
                 dto.setDireccion(rs.getString("direccion"));
                 dto.setCiudad(rs.getString("ciudad"));
+                dto.setCanton(rs.getString("canton"));
                 dto.setProvincia(rs.getString("provincia"));
                 dto.setCodigoPostal(rs.getString("codigo_postal"));
                 dto.setTelefonoContacto(rs.getString("telefono_contacto"));
@@ -73,6 +74,7 @@ public class DireccionDAO {
                 dto.setAlias(rs.getString("alias"));
                 dto.setDireccion(rs.getString("direccion"));
                 dto.setCiudad(rs.getString("ciudad"));
+                dto.setCanton(rs.getString("canton"));
                 dto.setProvincia(rs.getString("provincia"));
                 dto.setCodigoPostal(rs.getString("codigo_postal"));
                 dto.setTelefonoContacto(rs.getString("telefono_contacto"));
@@ -91,16 +93,17 @@ public class DireccionDAO {
                 fu.datosInvalidos("El usuario no existe");
                 return 0;
             }
-            String sql = "INSERT INTO direcciones(usuario_id, alias, direccion, ciudad, provincia, codigo_postal, telefono_contacto) VALUES(?,?,?,?,?,?,?)";
+            String sql = "INSERT INTO direcciones(usuario_id, alias, direccion, ciudad, canton, provincia, codigo_postal, telefono_contacto) VALUES(?,?,?,?,?,?,?,?)";
             ConectorBD ConnBD = new ConectorBD();
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             ps.setInt(1, dto.getUsuarioId());
             ps.setString(2, dto.getAlias());
             ps.setString(3, dto.getDireccion());
             ps.setString(4, dto.getCiudad());
-            ps.setString(5, dto.getProvincia());
-            ps.setString(6, dto.getCodigoPostal());
-            ps.setString(7, dto.getTelefonoContacto());
+            ps.setString(5, dto.getCanton());
+            ps.setString(6, dto.getProvincia());
+            ps.setString(7, dto.getCodigoPostal());
+            ps.setString(8, dto.getTelefonoContacto());
             ps.executeUpdate();
             ResultSet rs = ps.getGeneratedKeys();
             int codigo = 0;
@@ -120,17 +123,18 @@ public class DireccionDAO {
                 fu.datosInvalidos("El usuario no existe");
                 return 0;
             }
-            String sql = "UPDATE direcciones SET usuario_id=?, alias=?, direccion=?, ciudad=?, provincia=?, codigo_postal=?, telefono_contacto=? WHERE id=?";
+            String sql = "UPDATE direcciones SET usuario_id=?, alias=?, direccion=?, ciudad=?, canton=?, provincia=?, codigo_postal=?, telefono_contacto=? WHERE id=?";
             ConectorBD ConnBD = new ConectorBD();
             PreparedStatement ps = ConnBD.AbrirConexionBD().prepareStatement(sql);
             ps.setInt(1, dto.getUsuarioId());
             ps.setString(2, dto.getAlias());
             ps.setString(3, dto.getDireccion());
             ps.setString(4, dto.getCiudad());
-            ps.setString(5, dto.getProvincia());
-            ps.setString(6, dto.getCodigoPostal());
-            ps.setString(7, dto.getTelefonoContacto());
-            ps.setInt(8, dto.getId());
+            ps.setString(5, dto.getCanton());
+            ps.setString(6, dto.getProvincia());
+            ps.setString(7, dto.getCodigoPostal());
+            ps.setString(8, dto.getTelefonoContacto());
+            ps.setInt(9, dto.getId());
             int registros = ps.executeUpdate();
             if(registros==0){
                 fu.datosInvalidos("Dirección no encontrada");

--- a/src/dto/DireccionDTO.java
+++ b/src/dto/DireccionDTO.java
@@ -7,6 +7,7 @@ public class DireccionDTO {
     private String alias;
     private String direccion;
     private String ciudad;
+    private String canton;
     private String provincia;
     private String codigoPostal;
     private String telefonoContacto;
@@ -28,6 +29,9 @@ public class DireccionDTO {
 
     public String getCiudad() { return ciudad; }
     public void setCiudad(String ciudad) { this.ciudad = ciudad; }
+
+    public String getCanton() { return canton; }
+    public void setCanton(String canton) { this.canton = canton; }
 
     public String getProvincia() { return provincia; }
     public void setProvincia(String provincia) { this.provincia = provincia; }

--- a/src/proyectobd/DireccionesGui/Lst_Direcciones_Gui.fxml
+++ b/src/proyectobd/DireccionesGui/Lst_Direcciones_Gui.fxml
@@ -50,8 +50,8 @@
                   <Region HBox.hgrow="ALWAYS"/>
                   <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
                   <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
-                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
                   <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
                </HBox>
             </VBox>
          </bottom>

--- a/src/proyectobd/DireccionesGui/Lst_Direcciones_Gui.fxml
+++ b/src/proyectobd/DireccionesGui/Lst_Direcciones_Gui.fxml
@@ -35,6 +35,7 @@
                      <TableColumn fx:id="col_id" prefWidth="50.0" text="ID"/>
                      <TableColumn fx:id="col_usuario" prefWidth="150.0" text="Usuario"/>
                      <TableColumn fx:id="col_ciudad" prefWidth="100.0" text="Ciudad"/>
+                     <TableColumn fx:id="col_canton" prefWidth="100.0" text="Cantón"/>
                      <TableColumn fx:id="col_provincia" prefWidth="100.0" text="Provincia"/>
                   </columns>
                   <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>

--- a/src/proyectobd/DireccionesGui/Lst_Direcciones_GuiController.java
+++ b/src/proyectobd/DireccionesGui/Lst_Direcciones_GuiController.java
@@ -28,6 +28,7 @@ public class Lst_Direcciones_GuiController implements Initializable {
     @FXML private TableColumn<DireccionDTO, Integer> col_id;
     @FXML private TableColumn<DireccionDTO, String> col_usuario;
     @FXML private TableColumn<DireccionDTO, String> col_ciudad;
+    @FXML private TableColumn<DireccionDTO, String> col_canton;
     @FXML private TableColumn<DireccionDTO, String> col_provincia;
 
     FeedbackDireccion fu = new FeedbackDireccion();
@@ -52,6 +53,7 @@ public class Lst_Direcciones_GuiController implements Initializable {
                     new javafx.beans.property.ReadOnlyStringWrapper(
                         data.getValue().getUsuarioNombre() + " - ID " + data.getValue().getUsuarioId()));
             col_ciudad.setCellValueFactory(new PropertyValueFactory<>("ciudad"));
+            col_canton.setCellValueFactory(new PropertyValueFactory<>("canton"));
             col_provincia.setCellValueFactory(new PropertyValueFactory<>("provincia"));
             tbl_Lista.setItems(lista);
         }catch(Exception ex){

--- a/src/proyectobd/DireccionesGui/Mnt_Direcciones_Gui.fxml
+++ b/src/proyectobd/DireccionesGui/Mnt_Direcciones_Gui.fxml
@@ -37,12 +37,14 @@
                   <ComboBox fx:id="cmb_ciudad" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                   <Label text="Provincia:" GridPane.rowIndex="4" />
                   <ComboBox fx:id="cmb_provincia" GridPane.columnIndex="1" GridPane.rowIndex="4" />
-                  <Label text="Código Postal:" GridPane.rowIndex="5" />
-                  <TextField fx:id="txt_postal" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-                  <Label text="Teléfono:" GridPane.rowIndex="6" />
-                  <TextField fx:id="txt_telefono" GridPane.columnIndex="1" GridPane.rowIndex="6" />
-               </children>
-            </GridPane>
+                  <Label text="Cantón:" GridPane.rowIndex="5" />
+                  <ComboBox fx:id="cmb_canton" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                  <Label text="Código Postal:" GridPane.rowIndex="6" />
+                  <TextField fx:id="txt_postal" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+                  <Label text="Teléfono:" GridPane.rowIndex="7" />
+                  <TextField fx:id="txt_telefono" GridPane.columnIndex="1" GridPane.rowIndex="7" />
+              </children>
+           </GridPane>
          </center>
          <bottom>
             <HBox alignment="CENTER_RIGHT" spacing="10.0">

--- a/src/proyectobd/DireccionesGui/Mnt_Direcciones_GuiController.java
+++ b/src/proyectobd/DireccionesGui/Mnt_Direcciones_GuiController.java
@@ -18,11 +18,15 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackDireccion;
+import proyectobd.ParametrosGenerales.TextFilter;
+import java.util.HashMap;
+import java.util.List;
 
 public class Mnt_Direcciones_GuiController implements Initializable {
 
     FeedbackDireccion fu = new FeedbackDireccion();
     private boolean actualizar = false;
+    private final java.util.Map<String, java.util.Map<String, List<String>>> locationData = new HashMap<>();
 
     @FXML private BorderPane Ap_Main;
     @FXML private Button btn_Guardar;
@@ -30,6 +34,7 @@ public class Mnt_Direcciones_GuiController implements Initializable {
     @FXML private TextField txt_alias;
     @FXML private TextField txt_direccion;
     @FXML private ComboBox<String> cmb_ciudad;
+    @FXML private ComboBox<String> cmb_canton;
     @FXML private ComboBox<String> cmb_provincia;
     @FXML private TextField txt_postal;
     @FXML private TextField txt_telefono;
@@ -52,6 +57,7 @@ public class Mnt_Direcciones_GuiController implements Initializable {
                 dto.setAlias(txt_alias.getText());
                 dto.setDireccion(txt_direccion.getText());
                 dto.setCiudad(cmb_ciudad.getValue());
+                dto.setCanton(cmb_canton.getValue());
                 dto.setProvincia(cmb_provincia.getValue());
                 dto.setCodigoPostal(txt_postal.getText());
                 dto.setTelefonoContacto(txt_telefono.getText());
@@ -69,6 +75,7 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             dto.setAlias(txt_alias.getText());
             dto.setDireccion(txt_direccion.getText());
             dto.setCiudad(cmb_ciudad.getValue());
+            dto.setCanton(cmb_canton.getValue());
             dto.setProvincia(cmb_provincia.getValue());
             dto.setCodigoPostal(txt_postal.getText());
             dto.setTelefonoContacto(txt_telefono.getText());
@@ -92,6 +99,11 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             txt_alias.requestFocus();
             return false;
         }
+        if(TextFilter.contieneOfensas(txt_alias.getText())){
+            fu.datosInvalidos("Alias: contiene palabras ofensivas.");
+            txt_alias.requestFocus();
+            return false;
+        }
         if(txt_direccion.getText().trim().isEmpty()){
             fu.datosInvalidos("Direcci\u00f3n: ingrese un texto.");
             txt_direccion.requestFocus();
@@ -100,6 +112,11 @@ public class Mnt_Direcciones_GuiController implements Initializable {
         if(cmb_ciudad.getValue() == null){
             fu.datosInvalidos("Ciudad: seleccione un valor.");
             cmb_ciudad.requestFocus();
+            return false;
+        }
+        if(cmb_canton.getValue() == null){
+            fu.datosInvalidos("Cant\u00f3n: seleccione un valor.");
+            cmb_canton.requestFocus();
             return false;
         }
         if(cmb_provincia.getValue() == null){
@@ -125,8 +142,9 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             }
             txt_alias.setText(dto.getAlias());
             txt_direccion.setText(dto.getDireccion());
-            cmb_ciudad.setValue(dto.getCiudad());
             cmb_provincia.setValue(dto.getProvincia());
+            cmb_ciudad.setValue(dto.getCiudad());
+            cmb_canton.setValue(dto.getCanton());
             txt_postal.setText(dto.getCodigoPostal());
             txt_telefono.setText(dto.getTelefonoContacto());
         }
@@ -139,22 +157,43 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             usuarios.addAll(udao.ListarUsuarios());
             cmb_usuario.setItems(usuarios);
 
-            ObservableList<String> provincias = FXCollections.observableArrayList(
-                    "Azuay", "Bolívar", "Cañar", "Carchi", "Chimborazo",
-                    "Cotopaxi", "El Oro", "Esmeraldas", "Galápagos", "Guayas",
-                    "Imbabura", "Loja", "Los Ríos", "Manabí", "Morona Santiago",
-                    "Napo", "Orellana", "Pastaza", "Pichincha", "Santa Elena",
-                    "Santo Domingo", "Sucumbíos", "Tungurahua", "Zamora Chinchipe"
-            );
+            initUbicaciones();
+            ObservableList<String> provincias = FXCollections.observableArrayList(locationData.keySet());
             cmb_provincia.setItems(provincias);
 
-            ObservableList<String> ciudades = FXCollections.observableArrayList(
-                    "Quito", "Guayaquil", "Cuenca", "Ambato", "Manta",
-                    "Portoviejo", "Loja", "Machala", "Esmeraldas", "Santo Domingo"
-            );
-            cmb_ciudad.setItems(ciudades);
+            cmb_provincia.valueProperty().addListener((obs, oldV, newV) -> {
+                if(newV != null){
+                    java.util.Map<String, List<String>> ciudades = locationData.get(newV);
+                    cmb_ciudad.setItems(FXCollections.observableArrayList(ciudades.keySet()));
+                    cmb_ciudad.getSelectionModel().clearSelection();
+                    cmb_canton.getItems().clear();
+                }
+            });
+
+            cmb_ciudad.valueProperty().addListener((obs, oldV, newV) -> {
+                String provincia = cmb_provincia.getValue();
+                if(provincia != null && newV != null){
+                    List<String> cantones = locationData.get(provincia).get(newV);
+                    cmb_canton.setItems(FXCollections.observableArrayList(cantones));
+                    cmb_canton.getSelectionModel().clearSelection();
+                }
+            });
         } catch (Exception ex) {
             fu.MostrarAlertas("Error", ex.toString());
         }
+    }
+
+    private void initUbicaciones(){
+        if(!locationData.isEmpty()) return;
+        java.util.Map<String, List<String>> pichincha = new HashMap<>();
+        pichincha.put("Quito", java.util.Arrays.asList("Cayambe", "Mejía"));
+        pichincha.put("Rumiñahui", java.util.Arrays.asList("Sangolquí", "San Rafael"));
+
+        java.util.Map<String, List<String>> guayas = new HashMap<>();
+        guayas.put("Guayaquil", java.util.Arrays.asList("Guayaquil", "Samborondón"));
+        guayas.put("Daule", java.util.Arrays.asList("Daule", "Nobol"));
+
+        locationData.put("Pichincha", pichincha);
+        locationData.put("Guayas", guayas);
     }
 }

--- a/src/proyectobd/DireccionesGui/Mnt_Direcciones_GuiController.java
+++ b/src/proyectobd/DireccionesGui/Mnt_Direcciones_GuiController.java
@@ -193,7 +193,32 @@ public class Mnt_Direcciones_GuiController implements Initializable {
         guayas.put("Guayaquil", java.util.Arrays.asList("Guayaquil", "Samborondón"));
         guayas.put("Daule", java.util.Arrays.asList("Daule", "Nobol"));
 
+        java.util.Map<String, List<String>> azuay = new HashMap<>();
+        azuay.put("Cuenca", java.util.Arrays.asList("Cuenca", "Giron"));
+        azuay.put("Gualaceo", java.util.Arrays.asList("Gualaceo", "Chordeleg"));
+
+        java.util.Map<String, List<String>> manabi = new HashMap<>();
+        manabi.put("Portoviejo", java.util.Arrays.asList("Portoviejo", "Manta"));
+        manabi.put("Chone", java.util.Arrays.asList("Chone", "Pedernales"));
+
+        java.util.Map<String, List<String>> tungurahua = new HashMap<>();
+        tungurahua.put("Ambato", java.util.Arrays.asList("Ambato", "Baños"));
+        tungurahua.put("Pelileo", java.util.Arrays.asList("Pelileo", "Patate"));
+
+        java.util.Map<String, List<String>> chimborazo = new HashMap<>();
+        chimborazo.put("Riobamba", java.util.Arrays.asList("Riobamba", "Guano"));
+        chimborazo.put("Colta", java.util.Arrays.asList("Colta", "Chambo"));
+
+        java.util.Map<String, List<String>> loja = new HashMap<>();
+        loja.put("Loja", java.util.Arrays.asList("Loja", "Vilcabamba"));
+        loja.put("Catamayo", java.util.Arrays.asList("Catamayo", "Cariamanga"));
+
         locationData.put("Pichincha", pichincha);
         locationData.put("Guayas", guayas);
+        locationData.put("Azuay", azuay);
+        locationData.put("Manabí", manabi);
+        locationData.put("Tungurahua", tungurahua);
+        locationData.put("Chimborazo", chimborazo);
+        locationData.put("Loja", loja);
     }
 }

--- a/src/proyectobd/ParametrosGenerales/TextFilter.java
+++ b/src/proyectobd/ParametrosGenerales/TextFilter.java
@@ -1,0 +1,19 @@
+package proyectobd.ParametrosGenerales;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TextFilter {
+    private static final List<String> PALABRAS_OFENSIVAS = Arrays.asList(
+        "puta", "puto", "idiota", "imbecil", "mierda", "cabron", "verga"
+    );
+
+    public static boolean contieneOfensas(String texto){
+        if(texto == null) return false;
+        String lower = texto.toLowerCase();
+        for(String p : PALABRAS_OFENSIVAS){
+            if(lower.contains(p)) return true;
+        }
+        return false;
+    }
+}

--- a/src/proyectobd/RolesGui/Lst_Roles_Gui.fxml
+++ b/src/proyectobd/RolesGui/Lst_Roles_Gui.fxml
@@ -60,8 +60,8 @@
             <Region HBox.hgrow="ALWAYS" />
             <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
             <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
-            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
             <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
          </HBox>
       </VBox>
    </bottom>

--- a/src/proyectobd/UsuariosGui/Lst_Usuarios_Gui.fxml
+++ b/src/proyectobd/UsuariosGui/Lst_Usuarios_Gui.fxml
@@ -49,8 +49,8 @@
                   <Region HBox.hgrow="ALWAYS"/>
                   <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo"/>
                   <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar"/>
-                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
                   <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar"/>
+                  <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar"/>
                </HBox>
             </VBox>
          </bottom>

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
@@ -71,6 +71,11 @@ public class Mnt_Usuarios_GuiController implements Initializable {
             txt_email.requestFocus();
             return;
         }
+        if(TextFilter.contieneOfensas(txt_email.getText())){
+            fu.datosInvalidos("El campo 'Email' contiene palabras ofensivas.");
+            txt_email.requestFocus();
+            return;
+        }
         if(!actualizar){
             try{
                 UsuarioDTO dto = new UsuarioDTO();

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
@@ -24,6 +24,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackUsuario;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_Usuarios_GuiController implements Initializable {
     FeedbackUsuario fu = new FeedbackUsuario();
@@ -57,6 +58,11 @@ public class Mnt_Usuarios_GuiController implements Initializable {
         UsuarioDAO dao = new UsuarioDAO();
         if(!nombreValido(txt_nombre.getText())){
             fu.datosInvalidos("El campo 'Nombre' solo debe contener letras.");
+            txt_nombre.requestFocus();
+            return;
+        }
+        if(TextFilter.contieneOfensas(txt_nombre.getText())){
+            fu.datosInvalidos("El campo 'Nombre' contiene palabras ofensivas.");
             txt_nombre.requestFocus();
             return;
         }

--- a/src/proyectobd/VendedoresGui/Lst_Vendedores_Gui.fxml
+++ b/src/proyectobd/VendedoresGui/Lst_Vendedores_Gui.fxml
@@ -62,8 +62,8 @@
             <Region HBox.hgrow="ALWAYS" />
             <Button fx:id="btn_Nuevo" onAction="#call_NuevoRegistro" text="Nuevo" />
             <Button fx:id="btn_Editar" onAction="#call_Editar" text="Editar" />
-            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
             <Button fx:id="btn_Cerrar" onAction="#call_CerrarVentana" text="Cerrar" />
+            <Button fx:id="btn_Borrar" onAction="#call_Borrar" text="Borrar" />
          </HBox>
       </VBox>
    </bottom>

--- a/src/proyectobd/VendedoresGui/Mnt_Vendedores_GuiController.java
+++ b/src/proyectobd/VendedoresGui/Mnt_Vendedores_GuiController.java
@@ -18,6 +18,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackVendedor;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_Vendedores_GuiController implements Initializable {
 
@@ -44,6 +45,7 @@ public class Mnt_Vendedores_GuiController implements Initializable {
 
     public void call_Grabar(){
         VendedorDAO dao = new VendedorDAO();
+        if(!validarDatos()) return;
         if(!actualizar){
             try{
                 VendedorDTO dto = new VendedorDTO();
@@ -108,5 +110,47 @@ public class Mnt_Vendedores_GuiController implements Initializable {
         } catch (Exception ex) {
             fu.MostrarAlertas("Error", ex.toString());
         }
+    }
+
+    private boolean validarDatos(){
+        if(cmb_usuario.getValue() == null){
+            fu.datosInvalidos("Usuario: seleccione un valor.");
+            cmb_usuario.requestFocus();
+            return false;
+        }
+        if(cmb_tienda.getValue() == null){
+            fu.datosInvalidos("Tienda: seleccione un valor.");
+            cmb_tienda.requestFocus();
+            return false;
+        }
+        String desc = txt_descripcion.getText().trim();
+        if(desc.isEmpty()){
+            fu.datosInvalidos("Descripci\u00f3n: ingrese un texto.");
+            txt_descripcion.requestFocus();
+            return false;
+        }
+        if(TextFilter.contieneOfensas(desc)){
+            fu.datosInvalidos("Descripci\u00f3n contiene palabras ofensivas.");
+            txt_descripcion.requestFocus();
+            return false;
+        }
+        if(txt_calificacion.getText().trim().isEmpty()){
+            fu.datosInvalidos("Calificaci\u00f3n: ingrese un valor.");
+            txt_calificacion.requestFocus();
+            return false;
+        }
+        try{
+            java.math.BigDecimal val = new java.math.BigDecimal(txt_calificacion.getText());
+            if(val.compareTo(java.math.BigDecimal.ZERO) < 0 || val.compareTo(new java.math.BigDecimal("5")) > 0){
+                fu.datosInvalidos("Calificaci\u00f3n: debe estar entre 0 y 5.");
+                txt_calificacion.requestFocus();
+                return false;
+            }
+        }catch(NumberFormatException ex){
+            fu.datosInvalidos("Calificaci\u00f3n: valor num\u00e9rico inv\u00e1lido.");
+            txt_calificacion.requestFocus();
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- create `TextFilter` to detect offensive words
- validate names in usuarios against offensive words
- add profanity and canton validation in direcciones
- support canton column in DAO, DTO, and GUI
- unify vendedor validation and prevent offensive descriptions

## Testing
- `javac --module-path javafx-sdk-24.0.1/lib --add-modules javafx.controls,javafx.fxml -cp "jars/mysql-connector-j-8.4.0.jar" -d out $(find src -name "*.java")`

------
https://chatgpt.com/codex/tasks/task_e_6874753da0bc8332aec42fd1985c8bbc