### PR TITLE
Add text filter to remaining controllers

### DIFF
--- a/src/proyectobd/CategoriasGui/Mnt_Categorias_GuiController.java
+++ b/src/proyectobd/CategoriasGui/Mnt_Categorias_GuiController.java
@@ -17,6 +17,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackCategoria;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_Categorias_GuiController implements Initializable {
 
@@ -46,6 +47,11 @@ public class Mnt_Categorias_GuiController implements Initializable {
         CategoriaDAO dao = new CategoriaDAO();
         if(!nombreValido(txt_nombre.getText())){
             fu.datosInvalidos("El campo 'Nombre' solo debe contener letras.");
+            txt_nombre.requestFocus();
+            return;
+        }
+        if(TextFilter.contieneLenguajeInapropiado(txt_nombre.getText())){
+            fu.datosInvalidos("Nombre: contiene lenguaje inapropiado.");
             txt_nombre.requestFocus();
             return;
         }

--- a/src/proyectobd/DireccionesGui/Mnt_Direcciones_GuiController.java
+++ b/src/proyectobd/DireccionesGui/Mnt_Direcciones_GuiController.java
@@ -99,8 +99,8 @@ public class Mnt_Direcciones_GuiController implements Initializable {
             txt_alias.requestFocus();
             return false;
         }
-        if(TextFilter.contieneOfensas(txt_alias.getText())){
-            fu.datosInvalidos("Alias: contiene palabras ofensivas.");
+        if(TextFilter.contieneLenguajeInapropiado(txt_alias.getText())){
+            fu.datosInvalidos("Alias: contiene lenguaje inapropiado.");
             txt_alias.requestFocus();
             return false;
         }

--- a/src/proyectobd/EnviosGui/Mnt_Envios_GuiController.java
+++ b/src/proyectobd/EnviosGui/Mnt_Envios_GuiController.java
@@ -22,6 +22,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackEnvio;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_Envios_GuiController implements Initializable {
 
@@ -115,6 +116,16 @@ public class Mnt_Envios_GuiController implements Initializable {
         if(dp_entrega.getValue() == null){
             fu.datosInvalidos("Fecha Entrega: seleccione una fecha.");
             dp_entrega.requestFocus();
+            return false;
+        }
+        if(txt_tracking.getText().trim().isEmpty()){
+            fu.datosInvalidos("Tracking: ingrese un texto.");
+            txt_tracking.requestFocus();
+            return false;
+        }
+        if(TextFilter.contieneLenguajeInapropiado(txt_tracking.getText())){
+            fu.datosInvalidos("Tracking: contiene lenguaje inapropiado.");
+            txt_tracking.requestFocus();
             return false;
         }
         return true;

--- a/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_GuiController.java
+++ b/src/proyectobd/ImagenesProductoGui/Mnt_ImagenesProducto_GuiController.java
@@ -19,6 +19,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackImagenProducto;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_ImagenesProducto_GuiController implements Initializable {
 
@@ -48,6 +49,7 @@ public class Mnt_ImagenesProducto_GuiController implements Initializable {
 
     public void call_Grabar(){
         ImagenProductoDAO dao = new ImagenProductoDAO();
+        if(!validarDatos()) return;
         if(!actualizar){
             try{
                 ImagenProductoDTO dto = new ImagenProductoDTO();
@@ -110,6 +112,25 @@ public class Mnt_ImagenesProducto_GuiController implements Initializable {
             txt_url.setText(dto.getUrl());
             chk_principal.setSelected(dto.isEsPrincipal());
         }
+    }
+
+    private boolean validarDatos(){
+        if(cmb_producto.getValue() == null){
+            fu.datosInvalidos("Producto: seleccione un valor v\u00e1lido.");
+            cmb_producto.requestFocus();
+            return false;
+        }
+        if(txt_url.getText().trim().isEmpty()){
+            fu.datosInvalidos("URL: ingrese un texto.");
+            txt_url.requestFocus();
+            return false;
+        }
+        if(TextFilter.contieneLenguajeInapropiado(txt_url.getText())){
+            fu.datosInvalidos("URL contiene lenguaje inapropiado.");
+            txt_url.requestFocus();
+            return false;
+        }
+        return true;
     }
 
     private boolean existePrincipal(int productoId){

--- a/src/proyectobd/ListasDeseosGui/Mnt_ListasDeseos_GuiController.java
+++ b/src/proyectobd/ListasDeseosGui/Mnt_ListasDeseos_GuiController.java
@@ -20,6 +20,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackListaDeseo;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_ListasDeseos_GuiController implements Initializable {
 
@@ -42,6 +43,7 @@ public class Mnt_ListasDeseos_GuiController implements Initializable {
 
     public void call_Guardar(){
         ListaDeseoDAO dao = new ListaDeseoDAO();
+        if(!validarDatos()) return;
         if(!actualizar){
             try{
                 ListaDeseoDTO dto = new ListaDeseoDTO();
@@ -68,6 +70,30 @@ public class Mnt_ListasDeseos_GuiController implements Initializable {
                 fu.MostrarAlertas("Error", ex.toString());
             }
         }
+    }
+
+    private boolean validarDatos(){
+        if(cmb_usuario.getValue() == null){
+            fu.datosInvalidos("Usuario: seleccione un valor v\u00e1lido.");
+            cmb_usuario.requestFocus();
+            return false;
+        }
+        if(txt_nombre.getText().trim().isEmpty()){
+            fu.datosInvalidos("Nombre: ingrese un texto.");
+            txt_nombre.requestFocus();
+            return false;
+        }
+        if(TextFilter.contieneLenguajeInapropiado(txt_nombre.getText())){
+            fu.datosInvalidos("Nombre: contiene lenguaje inapropiado.");
+            txt_nombre.requestFocus();
+            return false;
+        }
+        if(dp_creado.getValue() == null){
+            fu.datosInvalidos("Fecha: seleccione una fecha.");
+            dp_creado.requestFocus();
+            return false;
+        }
+        return true;
     }
 
     private void cargarDatos(){

--- a/src/proyectobd/ParametrosGenerales/TextFilter.java
+++ b/src/proyectobd/ParametrosGenerales/TextFilter.java
@@ -8,6 +8,10 @@ public class TextFilter {
         "puta", "puto", "idiota", "imbecil", "mierda", "cabron", "verga"
     );
 
+    private static final List<String> PALABRAS_RACISTAS = Arrays.asList(
+        "nigger", "negrata", "sudaca", "cholo", "mayate"
+    );
+
     public static boolean contieneOfensas(String texto){
         if(texto == null) return false;
         String lower = texto.toLowerCase();
@@ -15,5 +19,18 @@ public class TextFilter {
             if(lower.contains(p)) return true;
         }
         return false;
+    }
+
+    public static boolean contieneRacismo(String texto){
+        if(texto == null) return false;
+        String lower = texto.toLowerCase();
+        for(String p : PALABRAS_RACISTAS){
+            if(lower.contains(p)) return true;
+        }
+        return false;
+    }
+
+    public static boolean contieneLenguajeInapropiado(String texto){
+        return contieneOfensas(texto) || contieneRacismo(texto);
     }
 }

--- a/src/proyectobd/ProductosGui/Mnt_Productos_GuiController.java
+++ b/src/proyectobd/ProductosGui/Mnt_Productos_GuiController.java
@@ -26,6 +26,7 @@ import javafx.scene.layout.BorderPane;
 import java.io.File;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackProducto;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_Productos_GuiController implements Initializable {
 
@@ -195,8 +196,16 @@ public class Mnt_Productos_GuiController implements Initializable {
             fu.datosInvalidos("El t\u00edtulo es obligatorio");
             return false;
         }
+        if(TextFilter.contieneLenguajeInapropiado(txt_titulo.getText())){
+            fu.datosInvalidos("T\u00edtulo contiene lenguaje inapropiado");
+            return false;
+        }
         if(txt_descripcion.getText().trim().isEmpty()){
             fu.datosInvalidos("La descripci\u00f3n es obligatoria");
+            return false;
+        }
+        if(TextFilter.contieneLenguajeInapropiado(txt_descripcion.getText())){
+            fu.datosInvalidos("Descripci\u00f3n contiene lenguaje inapropiado");
             return false;
         }
         return true;

--- a/src/proyectobd/ResenasGui/Mnt_Resenas_GuiController.java
+++ b/src/proyectobd/ResenasGui/Mnt_Resenas_GuiController.java
@@ -22,6 +22,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackResena;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_Resenas_GuiController implements Initializable {
 
@@ -76,8 +77,8 @@ public class Mnt_Resenas_GuiController implements Initializable {
             dp_fecha.requestFocus();
             return;
         }
-        if(contieneOfensivo(txt_comentario.getText())){
-            fu.datosInvalidos("Comentario contiene lenguaje ofensivo");
+        if(TextFilter.contieneLenguajeInapropiado(txt_comentario.getText())){
+            fu.datosInvalidos("Comentario contiene lenguaje inapropiado");
             txt_comentario.requestFocus();
             return;
         }
@@ -166,13 +167,4 @@ public class Mnt_Resenas_GuiController implements Initializable {
         }
     }
 
-    private boolean contieneOfensivo(String comentario){
-        if(comentario == null) return false;
-        String lower = comentario.toLowerCase();
-        String[] malas = {"tonto","idiota","malo"};
-        for(String m: malas){
-            if(lower.contains(m)) return true;
-        }
-        return false;
-    }
 }

--- a/src/proyectobd/RolesGui/Mnt_Roles_GuiController.java
+++ b/src/proyectobd/RolesGui/Mnt_Roles_GuiController.java
@@ -13,6 +13,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import proyectobd.ParametrosGenerales.FeedbackRol;
+import proyectobd.ParametrosGenerales.TextFilter;
 
 public class Mnt_Roles_GuiController implements Initializable {
 
@@ -36,6 +37,7 @@ public class Mnt_Roles_GuiController implements Initializable {
 
     public void call_Grabar(){
         RolDAO dao = new RolDAO();
+        if(!validarDatos()) return;
         if(!actualizar){
             try{
                 RolDTO dto = new RolDTO();
@@ -59,6 +61,20 @@ public class Mnt_Roles_GuiController implements Initializable {
                 fu.MostrarAlertas("Error", ex.toString());
             }
         }
+    }
+
+    private boolean validarDatos(){
+        if(txt_nombre.getText().trim().isEmpty()){
+            fu.datosInvalidos("Nombre: ingrese un texto.");
+            txt_nombre.requestFocus();
+            return false;
+        }
+        if(TextFilter.contieneLenguajeInapropiado(txt_nombre.getText())){
+            fu.datosInvalidos("Nombre: contiene lenguaje inapropiado.");
+            txt_nombre.requestFocus();
+            return false;
+        }
+        return true;
     }
 
     public void call_Borrar(){

--- a/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
+++ b/src/proyectobd/UsuariosGui/Mnt_Usuarios_GuiController.java
@@ -61,8 +61,8 @@ public class Mnt_Usuarios_GuiController implements Initializable {
             txt_nombre.requestFocus();
             return;
         }
-        if(TextFilter.contieneOfensas(txt_nombre.getText())){
-            fu.datosInvalidos("El campo 'Nombre' contiene palabras ofensivas.");
+        if(TextFilter.contieneLenguajeInapropiado(txt_nombre.getText())){
+            fu.datosInvalidos("El campo 'Nombre' contiene lenguaje inapropiado.");
             txt_nombre.requestFocus();
             return;
         }
@@ -71,8 +71,8 @@ public class Mnt_Usuarios_GuiController implements Initializable {
             txt_email.requestFocus();
             return;
         }
-        if(TextFilter.contieneOfensas(txt_email.getText())){
-            fu.datosInvalidos("El campo 'Email' contiene palabras ofensivas.");
+        if(TextFilter.contieneLenguajeInapropiado(txt_email.getText())){
+            fu.datosInvalidos("El campo 'Email' contiene lenguaje inapropiado.");
             txt_email.requestFocus();
             return;
         }

--- a/src/proyectobd/VendedoresGui/Mnt_Vendedores_GuiController.java
+++ b/src/proyectobd/VendedoresGui/Mnt_Vendedores_GuiController.java
@@ -129,8 +129,8 @@ public class Mnt_Vendedores_GuiController implements Initializable {
             txt_descripcion.requestFocus();
             return false;
         }
-        if(TextFilter.contieneOfensas(desc)){
-            fu.datosInvalidos("Descripci\u00f3n contiene palabras ofensivas.");
+        if(TextFilter.contieneLenguajeInapropiado(desc)){
+            fu.datosInvalidos("Descripci\u00f3n contiene lenguaje inapropiado.");
             txt_descripcion.requestFocus();
             return false;
         }


### PR DESCRIPTION
## Summary
- integrate `TextFilter` into categories, envios, images, lists, products, reviews, and roles controllers
- validate text inputs for inappropriate language

## Testing
- `javac -d /tmp src/proyectobd/ParametrosGenerales/TextFilter.java`
- `javac -classpath src src/proyectobd/CategoriasGui/Mnt_Categorias_GuiController.java` *(fails: package javafx.* does not exist)*
- `javac -classpath src src/proyectobd/RolesGui/Mnt_Roles_GuiController.java` *(fails: package javafx.* does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_6875149f84b08332970e59abc5c9f11c